### PR TITLE
Restore error reporting utilities

### DIFF
--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -2,7 +2,7 @@ import { GA_TRACKING_ID } from '@/config/env';
 import { logger } from './logger';
 
 // Strict event types
-export type AnalyticsEvent = 
+export type AnalyticsEvent =
   | 'page_view'
   | 'form_submit'
   | 'form_submit_success'
@@ -10,7 +10,8 @@ export type AnalyticsEvent =
   | 'demo_request'
   | 'language_switch'
   | 'cta_click'
-  | 'scroll_depth';
+  | 'scroll_depth'
+  | 'error';
 
 // Strict event parameters
 export interface EventParams {

--- a/src/utils/errorReporting.ts
+++ b/src/utils/errorReporting.ts
@@ -2,15 +2,83 @@ import { trackEvent } from './analytics';
 import { API_TIMEOUT_MS } from './constants';
 import { logger } from './logger';
 
-// ... rest of the code
+export enum ErrorSeverity {
+  Info = 'info',
+  Warning = 'warning',
+  Error = 'error',
+  Fatal = 'fatal',
+}
+
+export interface ErrorContext {
+  component?: string;
+  componentStack?: string;
+  errorBoundary?: boolean;
+  [key: string]: unknown;
+}
+
+export interface ErrorReport {
+  name?: string;
+  message: string;
+  stack?: string;
+  severity: ErrorSeverity;
+  timestamp: string;
+  context?: ErrorContext;
+}
+
+export interface CaptureErrorOptions {
+  severity?: ErrorSeverity;
+  context?: ErrorContext;
+}
+
+const severityToValue: Record<ErrorSeverity, number> = {
+  [ErrorSeverity.Info]: 1,
+  [ErrorSeverity.Warning]: 2,
+  [ErrorSeverity.Error]: 3,
+  [ErrorSeverity.Fatal]: 4,
+};
+
+export const captureError = (
+  error: unknown,
+  { severity = ErrorSeverity.Error, context }: CaptureErrorOptions = {}
+): void => {
+  const normalizedError =
+    error instanceof Error
+      ? error
+      : new Error(typeof error === 'string' ? error : 'Unknown error');
+
+  const errorReport: ErrorReport = {
+    name: normalizedError.name,
+    message: normalizedError.message,
+    stack: normalizedError.stack,
+    severity,
+    timestamp: new Date().toISOString(),
+    context,
+  };
+
+  const componentLabel = context?.component || normalizedError.name || 'Unknown';
+
+  logger.error('[Error Reporting] Captured error:', errorReport);
+
+  trackEvent('error', {
+    category: 'error_reporting',
+    label: componentLabel,
+    value: severityToValue[severity],
+    error: normalizedError.message,
+    severity,
+  });
+
+  void sendToErrorEndpoint(errorReport);
+};
 
 const sendToErrorEndpoint = async (errorReport: ErrorReport): Promise<void> => {
   const ERROR_ENDPOINT = process.env.NEXT_PUBLIC_ERROR_ENDPOINT;
-  
+
   if (!ERROR_ENDPOINT) return;
 
-  if (errorReport.severity !== ErrorSeverity.Error && 
-      errorReport.severity !== ErrorSeverity.Fatal) {
+  if (
+    errorReport.severity !== ErrorSeverity.Error &&
+    errorReport.severity !== ErrorSeverity.Fatal
+  ) {
     return;
   }
 
@@ -33,3 +101,5 @@ const sendToErrorEndpoint = async (errorReport: ErrorReport): Promise<void> => {
     logger.warn('[Error Reporting] Failed to send to custom endpoint:', error);
   }
 };
+
+export type { ErrorContext as ErrorReportingContext, ErrorReport };


### PR DESCRIPTION
## Summary
- restore the error reporting API including ErrorSeverity, ErrorContext, and ErrorReport
- implement captureError to normalize errors, track analytics, and forward to the error endpoint
- extend analytics events to support error reporting telemetry

## Testing
- npm run type-check *(fails: existing JSX syntax errors in src/components/TacTecLanding.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68db788bc4c0832a8b45ad73cdf65167