### PR TITLE
Fix secondary CTA markup on landing page

### DIFF
--- a/src/components/TacTecLanding.tsx
+++ b/src/components/TacTecLanding.tsx
@@ -2,7 +2,6 @@ import { useTranslations } from 'next-intl';
 import Head from 'next/head';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useRouter } from 'next/router';
 import LanguageSwitcher from './LanguageSwitcher';
 import StructuredData from './StructuredData';
 import { SITE_URL } from '@/config/env';
@@ -10,7 +9,6 @@ import { trackEvent } from '@/utils/analytics';
 
 export default function TacTecLanding() {
   const t = useTranslations();
-  const router = useRouter();
 
   const handleCTAClick = (type: string) => {
     trackEvent('cta_click', { type });
@@ -72,8 +70,10 @@ export default function TacTecLanding() {
               >
                 {t('hero.cta.demo')}
               </Link>
-              
+
+              <a
                 href="#features"
+                onClick={() => handleCTAClick('learn_more')}
                 className="border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 px-8 py-3 rounded-lg font-semibold transition"
               >
                 {t('hero.cta.start')}


### PR DESCRIPTION
## Summary
- wrap the secondary hero call-to-action in a proper anchor element so its attributes are valid JSX
- remove the unused `useRouter` import/variable from the landing page component
- trigger analytics tracking when the secondary call-to-action is clicked

## Testing
- npm run type-check *(fails: existing type errors in CookieConsent, ErrorBoundary, contact page, and utility modules)*

------
https://chatgpt.com/codex/tasks/task_e_68db797bc558832aa0f854eadff4d66b