### PR TITLE
Remove unused translations hook from cookie consent component

### DIFF
--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -1,12 +1,10 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { useTranslations } from 'next-intl';
 
 export default function CookieConsent() {
   const [showBanner, setShowBanner] = useState(false);
   const [mounted, setMounted] = useState(false);
   const router = useRouter();
-  const t = useTranslations();
 
   // First mount check
   useEffect(() => {


### PR DESCRIPTION
## Summary
- remove the unused `useTranslations` hook from the cookie consent banner to eliminate dead code

## Testing
- npm run type-check *(fails: existing JSX parse errors in src/components/TacTecLanding.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68db7a94aaf8832ab82738bac16abe76