### PR TITLE
Clean up unused imports and satisfy type checks

### DIFF
--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -1,12 +1,10 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { useTranslations } from 'next-intl';
 
 export default function CookieConsent() {
   const [showBanner, setShowBanner] = useState(false);
   const [mounted, setMounted] = useState(false);
   const router = useRouter();
-  const t = useTranslations();
 
   // First mount check
   useEffect(() => {

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -38,7 +38,7 @@ export class ErrorBoundary extends Component<Props, State> {
       severity: ErrorSeverity.Fatal,
       context: {
         component: 'ErrorBoundary',
-        componentStack: errorInfo.componentStack,
+        componentStack: errorInfo.componentStack || undefined,
         errorBoundary: true,
       },
     });

--- a/src/components/TacTecLanding.tsx
+++ b/src/components/TacTecLanding.tsx
@@ -2,7 +2,6 @@ import { useTranslations } from 'next-intl';
 import Head from 'next/head';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useRouter } from 'next/router';
 import LanguageSwitcher from './LanguageSwitcher';
 import StructuredData from './StructuredData';
 import { SITE_URL } from '@/config/env';
@@ -10,7 +9,6 @@ import { trackEvent } from '@/utils/analytics';
 
 export default function TacTecLanding() {
   const t = useTranslations();
-  const router = useRouter();
 
   const handleCTAClick = (type: string) => {
     trackEvent('cta_click', { type });
@@ -72,12 +70,12 @@ export default function TacTecLanding() {
               >
                 {t('hero.cta.demo')}
               </Link>
-              
+              <Link
                 href="#features"
                 className="border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 px-8 py-3 rounded-lg font-semibold transition"
               >
                 {t('hero.cta.start')}
-              </a>
+              </Link>
             </div>
           </div>
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -65,7 +65,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
         timeZone="UTC"
         now={new Date()}
         defaultTranslationValues={{
-          br: (chunks) => <br />,
+          br: () => <br />,
         }}
         onError={(error) => {
           if (process.env.NODE_ENV === 'development') {

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,6 +1,5 @@
 import Head from "next/head";
 import Link from "next/link";
-import { useRouter } from "next/router";
 import { useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -22,7 +21,6 @@ const contactFormSchema = z.object({
 type ContactFormData = z.infer<typeof contactFormSchema>;
 
 export default function ContactPage() {
-  const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitStatus, setSubmitStatus] = useState<"idle" | "success" | "error">("idle");
   const [submitMessage, setSubmitMessage] = useState("");
@@ -47,6 +45,7 @@ export default function ContactPage() {
       }, 8000);
       return () => clearTimeout(timer);
     }
+    return undefined;
   }, [submitStatus]);
 
   const onSubmit = async (data: ContactFormData) => {

--- a/src/utils/errorReporting.ts
+++ b/src/utils/errorReporting.ts
@@ -102,4 +102,4 @@ const sendToErrorEndpoint = async (errorReport: ErrorReport): Promise<void> => {
   }
 };
 
-export type { ErrorContext as ErrorReportingContext, ErrorReport };
+export type { ErrorContext as ErrorReportingContext };

--- a/src/utils/localeUtils.ts
+++ b/src/utils/localeUtils.ts
@@ -112,8 +112,10 @@ export async function loadLocaleMessages(context: GetStaticPropsContext) {
       
       console.log(`✅ Successfully loaded messages for locale: ${locale}`);
     } catch (localeError) {
-      console.warn(`⚠️ Failed to load locale ${locale}:`, localeError.message);
-      
+      const localeErrorMessage =
+        localeError instanceof Error ? localeError.message : String(localeError);
+      console.warn(`⚠️ Failed to load locale ${locale}:`, localeErrorMessage);
+
       try {
         // Fall back to English
         const fallbackContent = fs.readFileSync(fallbackPath, "utf-8");
@@ -125,8 +127,10 @@ export async function loadLocaleMessages(context: GetStaticPropsContext) {
         
         console.log(`✅ Loaded English fallback for locale: ${locale}`);
       } catch (fallbackError) {
-        console.error("❌ Failed to load English fallback:", fallbackError.message);
-        
+        const fallbackErrorMessage =
+          fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
+        console.error("❌ Failed to load English fallback:", fallbackErrorMessage);
+
         // Use hardcoded default messages
         messages = getDefaultMessages();
         console.log(`✅ Using default messages for locale: ${locale}`);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -29,7 +29,7 @@ class Logger {
     return this.levels[level] >= this.levels[this.config.minLevel || 'debug'];
   }
 
-  private formatMessage(level: LogLevel, message: string, ...args: any[]): string {
+  private formatMessage(level: LogLevel, message: string): string {
     const timestamp = new Date().toISOString();
     const prefix = `[${timestamp}] [${level.toUpperCase()}]`;
     return `${prefix} ${message}`;


### PR DESCRIPTION
## Summary
- remove the unused router hook on the contact page and ensure the effect callback always returns
- tidy up unused imports, fix CTA markup, and harden error and locale utilities against type errors
- simplify logger formatting and translation defaults to eliminate unused parameters

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68db7a8fe9dc832a9a0d75933439bd7e