### PR TITLE
Fix favicon references to match existing assets

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -28,52 +28,28 @@
   ],
   "icons": [
     {
-      "src": "/icons/icon-72x72.png",
-      "sizes": "72x72",
+      "src": "/icons/icon1.png",
+      "sizes": "96x96",
       "type": "image/png",
-      "purpose": "maskable any"
+      "purpose": "any"
     },
     {
-      "src": "/icons/icon-96x96.png",
-      "sizes": "96x96", 
+      "src": "/icons/apple-icon.png",
+      "sizes": "180x180",
       "type": "image/png",
-      "purpose": "maskable any"
+      "purpose": "any"
     },
     {
-      "src": "/icons/icon-128x128.png",
-      "sizes": "128x128",
-      "type": "image/png",
-      "purpose": "maskable any"
+      "src": "/icons/icon0.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
     },
     {
-      "src": "/icons/icon-144x144.png",
-      "sizes": "144x144",
-      "type": "image/png",
-      "purpose": "maskable any"
-    },
-    {
-      "src": "/icons/icon-152x152.png",
-      "sizes": "152x152",
-      "type": "image/png",
-      "purpose": "maskable any"
-    },
-    {
-      "src": "/icons/icon-192x192.png",
-      "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "maskable any"
-    },
-    {
-      "src": "/icons/icon-384x384.png",
-      "sizes": "384x384",
-      "type": "image/png",
-      "purpose": "maskable any"
-    },
-    {
-      "src": "/icons/icon-512x512.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "maskable any"
+      "src": "/icons/favicon.ico",
+      "sizes": "48x48 32x32 16x16",
+      "type": "image/x-icon",
+      "purpose": "any"
     }
   ],
   "shortcuts": [
@@ -84,8 +60,8 @@
       "url": "/#features",
       "icons": [
         {
-          "src": "/icons/shortcut-features.png",
-          "sizes": "192x192",
+          "src": "/icons/icon1.png",
+          "sizes": "96x96",
           "type": "image/png"
         }
       ]
@@ -97,8 +73,8 @@
       "url": "/#demo",
       "icons": [
         {
-          "src": "/icons/shortcut-demo.png", 
-          "sizes": "192x192",
+          "src": "/icons/icon1.png",
+          "sizes": "96x96",
           "type": "image/png"
         }
       ]
@@ -110,8 +86,8 @@
       "url": "/contact",
       "icons": [
         {
-          "src": "/icons/shortcut-contact.png",
-          "sizes": "192x192", 
+          "src": "/icons/icon1.png",
+          "sizes": "96x96",
           "type": "image/png"
         }
       ]

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -26,25 +26,12 @@ export default function MyDocument({ locale }: Props) {
         />
         
         {/* Favicon and App Icons */}
-        <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-        <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png" />
-        <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png" />
-        <link rel="icon" type="image/png" sizes="48x48" href="/icons/favicon-48x48.png" />
-        
+        <link rel="icon" type="image/x-icon" href="/icons/favicon.ico" />
+        <link rel="icon" type="image/png" sizes="96x96" href="/icons/icon1.png" />
+        <link rel="icon" type="image/svg+xml" href="/icons/icon0.svg" />
+
         {/* Apple Touch Icons */}
-        <link rel="apple-touch-icon" sizes="57x57" href="/icons/apple-touch-icon-57x57.png" />
-        <link rel="apple-touch-icon" sizes="60x60" href="/icons/apple-touch-icon-60x60.png" />
-        <link rel="apple-touch-icon" sizes="72x72" href="/icons/apple-touch-icon-72x72.png" />
-        <link rel="apple-touch-icon" sizes="76x76" href="/icons/apple-touch-icon-76x76.png" />
-        <link rel="apple-touch-icon" sizes="114x114" href="/icons/apple-touch-icon-114x114.png" />
-        <link rel="apple-touch-icon" sizes="120x120" href="/icons/apple-touch-icon-120x120.png" />
-        <link rel="apple-touch-icon" sizes="144x144" href="/icons/apple-touch-icon-144x144.png" />
-        <link rel="apple-touch-icon" sizes="152x152" href="/icons/apple-touch-icon-152x152.png" />
-        <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon-180x180.png" />
-        
-        {/* Android Chrome Icons */}
-        <link rel="icon" type="image/png" sizes="192x192" href="/icons/android-chrome-192x192.png" />
-        <link rel="icon" type="image/png" sizes="512x512" href="/icons/android-chrome-512x512.png" />
+        <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-icon.png" />
         
         {/* PWA Manifest */}
         <link rel="manifest" href="/manifest.json" />
@@ -52,7 +39,7 @@ export default function MyDocument({ locale }: Props) {
         {/* Theme Colors */}
         <meta name="theme-color" content="#0ea5e9" />
         <meta name="msapplication-TileColor" content="#0ea5e9" />
-        <meta name="msapplication-TileImage" content="/icons/mstile-144x144.png" />
+        <meta name="msapplication-TileImage" content="/icons/apple-icon.png" />
         <meta name="msapplication-config" content="/browserconfig.xml" />
         
         {/* iOS Specific */}


### PR DESCRIPTION
## Summary
- update the custom document to only reference favicon and touch icon files that exist in the repository
- trim the web app manifest to use the same set of available icons for app shortcuts and install prompts

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68db815fdeec832ab921166b5b471404