### PR TITLE
Handle consent updates via cookie banner callbacks

### DIFF
--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 
-export default function CookieConsent() {
+type ConsentStatus = 'accepted' | 'declined';
+
+interface CookieConsentProps {
+  onConsentChange?: (status: ConsentStatus) => void;
+}
+
+export default function CookieConsent({ onConsentChange }: CookieConsentProps) {
   const [showBanner, setShowBanner] = useState(false);
   const [mounted, setMounted] = useState(false);
   const router = useRouter();
@@ -32,17 +38,24 @@ export default function CookieConsent() {
     }
   };
 
+  const notifyConsentChange = (status: ConsentStatus) => {
+    if (typeof onConsentChange === 'function') {
+      onConsentChange(status);
+    }
+  };
+
   const handleAccept = () => {
     if (typeof window === 'undefined') return;
-    
+
     localStorage.setItem('cookie-consent', 'accepted');
     enableAnalytics();
     setShowBanner(false);
+    notifyConsentChange('accepted');
   };
 
   const handleDecline = () => {
     if (typeof window === 'undefined') return;
-    
+
     localStorage.setItem('cookie-consent', 'declined');
     if (typeof window !== 'undefined' && window.gtag) {
       window.gtag('consent', 'update', {
@@ -51,6 +64,7 @@ export default function CookieConsent() {
       });
     }
     setShowBanner(false);
+    notifyConsentChange('declined');
   };
 
   // Don't render until mounted

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -99,7 +99,11 @@ export default function MyApp({ Component, pageProps }: AppProps) {
           </>
         )}
         
-        <CookieConsent />
+        <CookieConsent
+          onConsentChange={(status) => {
+            setConsentGiven(status === "accepted");
+          }}
+        />
         <Component {...pageProps} />
       </NextIntlClientProvider>
     </ErrorBoundary>


### PR DESCRIPTION
## Summary
- pass an onConsentChange callback from _app.tsx to keep consent state in sync
- allow the CookieConsent component to invoke the callback after accepting or declining
- ensure analytics scripts load immediately when consent is given and remain disabled when declined

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db815b4120832a8c0b814b4eb86ffa