### PR TITLE
Add skip link targets to main content areas

### DIFF
--- a/src/components/TacTecLanding.tsx
+++ b/src/components/TacTecLanding.tsx
@@ -1,17 +1,17 @@
-import { useTranslations } from 'next-intl';
-import Head from 'next/head';
-import Image from 'next/image';
-import Link from 'next/link';
-import LanguageSwitcher from './LanguageSwitcher';
-import StructuredData from './StructuredData';
-import { SITE_URL } from '@/config/env';
-import { trackEvent } from '@/utils/analytics';
+import { useTranslations } from "next-intl";
+import Head from "next/head";
+import Image from "next/image";
+import Link from "next/link";
+import LanguageSwitcher from "./LanguageSwitcher";
+import StructuredData from "./StructuredData";
+import { SITE_URL } from "@/config/env";
+import { trackEvent } from "@/utils/analytics";
 
 export default function TacTecLanding() {
   const t = useTranslations();
 
   const handleCTAClick = (type: string) => {
-    trackEvent('cta_click', { type });
+    trackEvent("cta_click", { type });
   };
 
   return (
@@ -23,11 +23,20 @@ export default function TacTecLanding() {
           content="TACTEC unifies tactical, medical, and operational workflows into one professional platform for football clubs."
         />
         <link rel="canonical" href={SITE_URL} />
-        <meta property="og:title" content="TACTEC – Revolutionising Football Club Management" />
-        <meta property="og:description" content="Professional football club management platform" />
+        <meta
+          property="og:title"
+          content="TACTEC – Revolutionising Football Club Management"
+        />
+        <meta
+          property="og:description"
+          content="Professional football club management platform"
+        />
         <meta property="og:type" content="website" />
         <meta property="og:url" content={SITE_URL} />
-        <meta property="og:image" content={`${SITE_URL}/images/1_TacTec-Revolutionising-Football-Club-Management.webp`} />
+        <meta
+          property="og:image"
+          content={`${SITE_URL}/images/1_TacTec-Revolutionising-Football-Club-Management.webp`}
+        />
       </Head>
 
       <StructuredData type="softwareApplication" />
@@ -36,14 +45,23 @@ export default function TacTecLanding() {
       <nav className="bg-white/90 dark:bg-gray-900/90 backdrop-blur-sm border-b sticky top-0 z-50">
         <div className="container mx-auto px-6 py-4">
           <div className="flex justify-between items-center">
-            <Link href="/" className="text-2xl font-bold text-sky-600 hover:text-sky-700 transition">
+            <Link
+              href="/"
+              className="text-2xl font-bold text-sky-600 hover:text-sky-700 transition"
+            >
               TACTEC
             </Link>
             <div className="flex items-center gap-6">
               <div className="hidden md:flex gap-6">
-                <a href="#features" className="hover:text-sky-600 transition">{t('nav.features')}</a>
-                <a href="#tech" className="hover:text-sky-600 transition">{t('nav.tech')}</a>
-                <Link href="/contact" className="hover:text-sky-600 transition">{t('nav.contact')}</Link>
+                <a href="#features" className="hover:text-sky-600 transition">
+                  {t("nav.features")}
+                </a>
+                <a href="#tech" className="hover:text-sky-600 transition">
+                  {t("nav.tech")}
+                </a>
+                <Link href="/contact" className="hover:text-sky-600 transition">
+                  {t("nav.contact")}
+                </Link>
               </div>
               <LanguageSwitcher />
             </div>
@@ -51,136 +69,168 @@ export default function TacTecLanding() {
         </div>
       </nav>
 
-      {/* Hero Section */}
-      <section className="relative bg-gradient-to-b from-gray-50 to-white dark:from-gray-900 dark:to-gray-800 py-20">
-        <div className="container mx-auto px-6">
-          <div className="max-w-4xl mx-auto text-center">
-            <p className="text-sky-600 font-semibold mb-4">{t('hero.trusted')}</p>
-            <h1 className="text-5xl md:text-6xl font-bold mb-6">
-              {t('hero.title')} <span className="text-sky-600">{t('hero.title_highlight')}</span>
-            </h1>
-            <p className="text-xl text-gray-600 dark:text-gray-400 mb-8">
-              {t('hero.subtitle')}
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link
-                href="/contact"
-                onClick={() => handleCTAClick('demo')}
-                className="bg-sky-500 hover:bg-sky-600 text-white px-8 py-3 rounded-lg font-semibold transition"
-              >
-                {t('hero.cta.demo')}
-              </Link>
-              <Link
-                href="#features"
-                className="border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 px-8 py-3 rounded-lg font-semibold transition"
-              >
-                {t('hero.cta.start')}
-              </Link>
+      <main id="content" tabIndex={-1}>
+        {/* Hero Section */}
+        <section className="relative bg-gradient-to-b from-gray-50 to-white dark:from-gray-900 dark:to-gray-800 py-20">
+          <div className="container mx-auto px-6">
+            <div className="max-w-4xl mx-auto text-center">
+              <p className="text-sky-600 font-semibold mb-4">
+                {t("hero.trusted")}
+              </p>
+              <h1 className="text-5xl md:text-6xl font-bold mb-6">
+                {t("hero.title")}{" "}
+                <span className="text-sky-600">
+                  {t("hero.title_highlight")}
+                </span>
+              </h1>
+              <p className="text-xl text-gray-600 dark:text-gray-400 mb-8">
+                {t("hero.subtitle")}
+              </p>
+              <div className="flex flex-col sm:flex-row gap-4 justify-center">
+                <Link
+                  href="/contact"
+                  onClick={() => handleCTAClick("demo")}
+                  className="bg-sky-500 hover:bg-sky-600 text-white px-8 py-3 rounded-lg font-semibold transition"
+                >
+                  {t("hero.cta.demo")}
+                </Link>
+                <Link
+                  href="#features"
+                  className="border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 px-8 py-3 rounded-lg font-semibold transition"
+                >
+                  {t("hero.cta.start")}
+                </Link>
+              </div>
+            </div>
+
+            <div className="mt-16 max-w-5xl mx-auto">
+              <div className="relative rounded-lg overflow-hidden shadow-2xl">
+                <Image
+                  src="/images/1_TacTec-Revolutionising-Football-Club-Management.webp"
+                  alt="TACTEC revolutionising football club management"
+                  width={1920}
+                  height={1080}
+                  priority
+                  sizes="(max-width: 640px) 100vw, (max-width: 1024px) 80vw, 1000px"
+                  quality={90}
+                  className="rounded-lg"
+                />
+              </div>
             </div>
           </div>
+        </section>
 
-          <div className="mt-16 max-w-5xl mx-auto">
-            <div className="relative rounded-lg overflow-hidden shadow-2xl">
+        {/* Challenge Section */}
+        <section id="challenge" className="py-20 bg-white dark:bg-gray-900">
+          <div className="container mx-auto px-6">
+            <div className="max-w-4xl mx-auto text-center mb-16">
+              <p className="text-sky-600 font-semibold mb-4">
+                {t("challenge.eyebrow")}
+              </p>
+              <h2 className="text-4xl font-bold mb-4">
+                {t("challenge.title")}
+              </h2>
+              <p className="text-xl text-gray-600 dark:text-gray-400">
+                {t("challenge.subtitle")}
+              </p>
+            </div>
+
+            <div className="grid md:grid-cols-3 gap-8 max-w-6xl mx-auto">
+              {["staff", "workflows", "insights"].map((item) => (
+                <div
+                  key={item}
+                  className="bg-gray-50 dark:bg-gray-800 p-6 rounded-xl"
+                >
+                  <h3 className="text-xl font-semibold mb-3">
+                    {t(`challenge.items.${item}.title`)}
+                  </h3>
+                  <p className="text-gray-600 dark:text-gray-400">
+                    {t(`challenge.items.${item}.desc`)}
+                  </p>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-16 max-w-5xl mx-auto">
               <Image
-                src="/images/1_TacTec-Revolutionising-Football-Club-Management.webp"
-                alt="TACTEC revolutionising football club management"
+                src="/images/2_The-Challenge-Fragmented-Football-Operations.webp"
+                alt="Challenge – Fragmented football operations"
                 width={1920}
                 height={1080}
-                priority
+                loading="lazy"
                 sizes="(max-width: 640px) 100vw, (max-width: 1024px) 80vw, 1000px"
-                quality={90}
-                className="rounded-lg"
+                quality={85}
+                className="rounded-lg shadow-lg"
               />
             </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      {/* Challenge Section */}
-      <section id="challenge" className="py-20 bg-white dark:bg-gray-900">
-        <div className="container mx-auto px-6">
-          <div className="max-w-4xl mx-auto text-center mb-16">
-            <p className="text-sky-600 font-semibold mb-4">{t('challenge.eyebrow')}</p>
-            <h2 className="text-4xl font-bold mb-4">{t('challenge.title')}</h2>
-            <p className="text-xl text-gray-600 dark:text-gray-400">{t('challenge.subtitle')}</p>
-          </div>
-
-          <div className="grid md:grid-cols-3 gap-8 max-w-6xl mx-auto">
-            {['staff', 'workflows', 'insights'].map((item) => (
-              <div key={item} className="bg-gray-50 dark:bg-gray-800 p-6 rounded-xl">
-                <h3 className="text-xl font-semibold mb-3">{t(`challenge.items.${item}.title`)}</h3>
-                <p className="text-gray-600 dark:text-gray-400">{t(`challenge.items.${item}.desc`)}</p>
-              </div>
-            ))}
-          </div>
-
-          <div className="mt-16 max-w-5xl mx-auto">
-            <Image
-              src="/images/2_The-Challenge-Fragmented-Football-Operations.webp"
-              alt="Challenge – Fragmented football operations"
-              width={1920}
-              height={1080}
-              loading="lazy"
-              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 80vw, 1000px"
-              quality={85}
-              className="rounded-lg shadow-lg"
-            />
-          </div>
-        </div>
-      </section>
-
-      {/* Solution Section */}
-      <section id="solution" className="py-20 bg-gray-50 dark:bg-gray-800">
-        <div className="container mx-auto px-6">
-          <div className="max-w-4xl mx-auto text-center">
-            <p className="text-sky-600 font-semibold mb-4">{t('solution.eyebrow')}</p>
-            <h2 className="text-4xl font-bold mb-4">{t('solution.title')}</h2>
-            <p className="text-xl text-gray-600 dark:text-gray-400">{t('solution.subtitle')}</p>
-          </div>
-        </div>
-      </section>
-
-      {/* Features Section */}
-      <section id="features" className="py-20 bg-white dark:bg-gray-900">
-        <div className="container mx-auto px-6">
-          <div className="max-w-4xl mx-auto text-center">
-            <p className="text-sky-600 font-semibold mb-4">{t('features.eyebrow')}</p>
-            <h2 className="text-4xl font-bold mb-4">{t('features.title')}</h2>
-            <p className="text-xl text-gray-600 dark:text-gray-400">{t('features.subtitle')}</p>
-          </div>
-        </div>
-      </section>
-
-      {/* Tech Section */}
-      <section id="tech" className="py-20 bg-gray-50 dark:bg-gray-800">
-        <div className="container mx-auto px-6">
-          <div className="max-w-4xl mx-auto text-center">
-            <p className="text-sky-600 font-semibold mb-4">{t('tech.eyebrow')}</p>
-            <h2 className="text-4xl font-bold mb-4">{t('tech.title')}</h2>
-            <p className="text-xl text-gray-600 dark:text-gray-400">{t('tech.subtitle')}</p>
-          </div>
-        </div>
-      </section>
-
-      {/* CTA Section */}
-      <section id="demo" className="py-20 bg-sky-600 text-white">
-        <div className="container mx-auto px-6">
-          <div className="max-w-4xl mx-auto text-center">
-            <p className="font-semibold mb-4">{t('cta.eyebrow')}</p>
-            <h2 className="text-4xl font-bold mb-4">{t('cta.title')}</h2>
-            <p className="text-xl mb-8">{t('cta.subtitle')}</p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link
-                href="/contact"
-                onClick={() => handleCTAClick('live_demo')}
-                className="bg-white text-sky-600 hover:bg-gray-100 px-8 py-3 rounded-lg font-semibold transition"
-              >
-                {t('cta.buttons.demo')}
-              </Link>
+        {/* Solution Section */}
+        <section id="solution" className="py-20 bg-gray-50 dark:bg-gray-800">
+          <div className="container mx-auto px-6">
+            <div className="max-w-4xl mx-auto text-center">
+              <p className="text-sky-600 font-semibold mb-4">
+                {t("solution.eyebrow")}
+              </p>
+              <h2 className="text-4xl font-bold mb-4">{t("solution.title")}</h2>
+              <p className="text-xl text-gray-600 dark:text-gray-400">
+                {t("solution.subtitle")}
+              </p>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
+
+        {/* Features Section */}
+        <section id="features" className="py-20 bg-white dark:bg-gray-900">
+          <div className="container mx-auto px-6">
+            <div className="max-w-4xl mx-auto text-center">
+              <p className="text-sky-600 font-semibold mb-4">
+                {t("features.eyebrow")}
+              </p>
+              <h2 className="text-4xl font-bold mb-4">{t("features.title")}</h2>
+              <p className="text-xl text-gray-600 dark:text-gray-400">
+                {t("features.subtitle")}
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Tech Section */}
+        <section id="tech" className="py-20 bg-gray-50 dark:bg-gray-800">
+          <div className="container mx-auto px-6">
+            <div className="max-w-4xl mx-auto text-center">
+              <p className="text-sky-600 font-semibold mb-4">
+                {t("tech.eyebrow")}
+              </p>
+              <h2 className="text-4xl font-bold mb-4">{t("tech.title")}</h2>
+              <p className="text-xl text-gray-600 dark:text-gray-400">
+                {t("tech.subtitle")}
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* CTA Section */}
+        <section id="demo" className="py-20 bg-sky-600 text-white">
+          <div className="container mx-auto px-6">
+            <div className="max-w-4xl mx-auto text-center">
+              <p className="font-semibold mb-4">{t("cta.eyebrow")}</p>
+              <h2 className="text-4xl font-bold mb-4">{t("cta.title")}</h2>
+              <p className="text-xl mb-8">{t("cta.subtitle")}</p>
+              <div className="flex flex-col sm:flex-row gap-4 justify-center">
+                <Link
+                  href="/contact"
+                  onClick={() => handleCTAClick("live_demo")}
+                  className="bg-white text-sky-600 hover:bg-gray-100 px-8 py-3 rounded-lg font-semibold transition"
+                >
+                  {t("cta.buttons.demo")}
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
 
       {/* Footer */}
       <footer className="bg-gray-900 text-gray-400 py-12">
@@ -188,26 +238,46 @@ export default function TacTecLanding() {
           <div className="grid md:grid-cols-3 gap-8 mb-8">
             <div>
               <h3 className="text-white font-semibold mb-4">TACTEC</h3>
-              <p className="text-sm">{t('footer.about')}</p>
+              <p className="text-sm">{t("footer.about")}</p>
             </div>
             <div>
-              <h3 className="text-white font-semibold mb-4">{t('footer.product')}</h3>
+              <h3 className="text-white font-semibold mb-4">
+                {t("footer.product")}
+              </h3>
               <ul className="space-y-2 text-sm">
-                <li><a href="#features" className="hover:text-white transition">{t('nav.features')}</a></li>
-                <li><a href="#tech" className="hover:text-white transition">{t('nav.tech')}</a></li>
+                <li>
+                  <a href="#features" className="hover:text-white transition">
+                    {t("nav.features")}
+                  </a>
+                </li>
+                <li>
+                  <a href="#tech" className="hover:text-white transition">
+                    {t("nav.tech")}
+                  </a>
+                </li>
               </ul>
             </div>
             <div>
-              <h3 className="text-white font-semibold mb-4">{t('footer.company')}</h3>
+              <h3 className="text-white font-semibold mb-4">
+                {t("footer.company")}
+              </h3>
               <ul className="space-y-2 text-sm">
-                <li><Link href="/contact" className="hover:text-white transition">{t('nav.contact')}</Link></li>
-                <li><Link href="/privacy" className="hover:text-white transition">Privacy Policy</Link></li>
+                <li>
+                  <Link href="/contact" className="hover:text-white transition">
+                    {t("nav.contact")}
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/privacy" className="hover:text-white transition">
+                    Privacy Policy
+                  </Link>
+                </li>
               </ul>
             </div>
           </div>
           <div className="border-t border-gray-800 pt-8 text-center text-sm">
-            <p>{t('footer.rights')}</p>
-            <p className="mt-2 text-sky-400">{t('footer.made')}</p>
+            <p>{t("footer.rights")}</p>
+            <p className="mt-2 text-sky-400">{t("footer.made")}</p>
           </div>
         </div>
       </footer>

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -22,7 +22,9 @@ type ContactFormData = z.infer<typeof contactFormSchema>;
 
 export default function ContactPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [submitStatus, setSubmitStatus] = useState<"idle" | "success" | "error">("idle");
+  const [submitStatus, setSubmitStatus] = useState<
+    "idle" | "success" | "error"
+  >("idle");
   const [submitMessage, setSubmitMessage] = useState("");
 
   const {
@@ -72,7 +74,7 @@ export default function ContactPage() {
       if (response.ok && result.success) {
         setSubmitStatus("success");
         setSubmitMessage(
-          result.message || "Your message has been sent successfully!"
+          result.message || "Your message has been sent successfully!",
         );
         reset();
 
@@ -101,7 +103,7 @@ export default function ContactPage() {
       setSubmitMessage(
         error instanceof Error
           ? error.message
-          : "Something went wrong. Please try again or email us directly."
+          : "Something went wrong. Please try again or email us directly.",
       );
 
       trackEvent("form_submit_error", {
@@ -157,7 +159,11 @@ export default function ContactPage() {
       </nav>
 
       {/* Page Content */}
-      <main className="min-h-screen bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-800">
+      <main
+        id="content"
+        tabIndex={-1}
+        className="min-h-screen bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-800"
+      >
         <div className="container mx-auto px-6 py-16">
           <div className="max-w-4xl mx-auto">
             {/* Header */}
@@ -166,7 +172,8 @@ export default function ContactPage() {
                 Get in Touch
               </h1>
               <p className="text-lg text-gray-600 dark:text-gray-400">
-                Ready to transform your club? Request a demo or contact our team.
+                Ready to transform your club? Request a demo or contact our
+                team.
               </p>
             </div>
 
@@ -202,7 +209,9 @@ export default function ContactPage() {
                     <option value="general">General Question</option>
                   </select>
                   {errors.requestType && (
-                    <p className="mt-1 text-sm text-red-600">{errors.requestType.message}</p>
+                    <p className="mt-1 text-sm text-red-600">
+                      {errors.requestType.message}
+                    </p>
                   )}
                 </div>
 
@@ -218,7 +227,9 @@ export default function ContactPage() {
                     placeholder="John Doe"
                   />
                   {errors.name && (
-                    <p className="mt-1 text-sm text-red-600">{errors.name.message}</p>
+                    <p className="mt-1 text-sm text-red-600">
+                      {errors.name.message}
+                    </p>
                   )}
                 </div>
 
@@ -234,7 +245,9 @@ export default function ContactPage() {
                     placeholder="john@club.com"
                   />
                   {errors.email && (
-                    <p className="mt-1 text-sm text-red-600">{errors.email.message}</p>
+                    <p className="mt-1 text-sm text-red-600">
+                      {errors.email.message}
+                    </p>
                   )}
                 </div>
 
@@ -250,7 +263,9 @@ export default function ContactPage() {
                     placeholder="FC Example"
                   />
                   {errors.club && (
-                    <p className="mt-1 text-sm text-red-600">{errors.club.message}</p>
+                    <p className="mt-1 text-sm text-red-600">
+                      {errors.club.message}
+                    </p>
                   )}
                 </div>
 
@@ -266,7 +281,9 @@ export default function ContactPage() {
                     placeholder="Manager, Coach, Director, etc."
                   />
                   {errors.role && (
-                    <p className="mt-1 text-sm text-red-600">{errors.role.message}</p>
+                    <p className="mt-1 text-sm text-red-600">
+                      {errors.role.message}
+                    </p>
                   )}
                 </div>
 
@@ -282,7 +299,9 @@ export default function ContactPage() {
                     placeholder="Tell us about your needs..."
                   />
                   {errors.message && (
-                    <p className="mt-1 text-sm text-red-600">{errors.message.message}</p>
+                    <p className="mt-1 text-sm text-red-600">
+                      {errors.message.message}
+                    </p>
                   )}
                 </div>
 
@@ -294,9 +313,24 @@ export default function ContactPage() {
                 >
                   {isSubmitting ? (
                     <>
-                      <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" fill="none" viewBox="0 0 24 24">
-                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"/>
-                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
+                      <svg
+                        className="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                      >
+                        <circle
+                          className="opacity-25"
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke="currentColor"
+                          strokeWidth="4"
+                        />
+                        <path
+                          className="opacity-75"
+                          fill="currentColor"
+                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                        />
                       </svg>
                       Sending...
                     </>
@@ -311,34 +345,71 @@ export default function ContactPage() {
             <div className="mt-12 grid md:grid-cols-3 gap-8">
               <div className="text-center">
                 <div className="w-12 h-12 bg-sky-100 dark:bg-sky-900 rounded-lg flex items-center justify-center mx-auto mb-4">
-                  <svg className="w-6 h-6 text-sky-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                  <svg
+                    className="w-6 h-6 text-sky-600"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                    />
                   </svg>
                 </div>
                 <h3 className="font-semibold mb-2">Email</h3>
-                <a href="mailto:info@tactec.club" className="text-sky-600 hover:underline">
+                <a
+                  href="mailto:info@tactec.club"
+                  className="text-sky-600 hover:underline"
+                >
                   info@tactec.club
                 </a>
               </div>
 
               <div className="text-center">
                 <div className="w-12 h-12 bg-sky-100 dark:bg-sky-900 rounded-lg flex items-center justify-center mx-auto mb-4">
-                  <svg className="w-6 h-6 text-sky-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  <svg
+                    className="w-6 h-6 text-sky-600"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                    />
                   </svg>
                 </div>
                 <h3 className="font-semibold mb-2">Response Time</h3>
-                <p className="text-gray-600 dark:text-gray-400">Within 24 hours</p>
+                <p className="text-gray-600 dark:text-gray-400">
+                  Within 24 hours
+                </p>
               </div>
 
               <div className="text-center">
                 <div className="w-12 h-12 bg-sky-100 dark:bg-sky-900 rounded-lg flex items-center justify-center mx-auto mb-4">
-                  <svg className="w-6 h-6 text-sky-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" />
+                  <svg
+                    className="w-6 h-6 text-sky-600"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"
+                    />
                   </svg>
                 </div>
                 <h3 className="font-semibold mb-2">Languages</h3>
-                <p className="text-gray-600 dark:text-gray-400">8 languages supported</p>
+                <p className="text-gray-600 dark:text-gray-400">
+                  8 languages supported
+                </p>
               </div>
             </div>
           </div>
@@ -349,7 +420,9 @@ export default function ContactPage() {
       <footer className="bg-gray-900 text-gray-400 py-8">
         <div className="container mx-auto px-6 text-center">
           <p className="text-sm">© Ventio. All rights reserved.</p>
-          <p className="mt-2 text-sky-400 text-sm">Made with care for football.</p>
+          <p className="mt-2 text-sky-400 text-sm">
+            Made with care for football.
+          </p>
         </div>
       </footer>
     </>
@@ -360,8 +433,18 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
   const fs = await import("fs");
   const path = await import("path");
 
-  const filePath = path.join(process.cwd(), "src/locales", locale || "en", "common.json");
-  const fallbackPath = path.join(process.cwd(), "src/locales", "en", "common.json");
+  const filePath = path.join(
+    process.cwd(),
+    "src/locales",
+    locale || "en",
+    "common.json",
+  );
+  const fallbackPath = path.join(
+    process.cwd(),
+    "src/locales",
+    "en",
+    "common.json",
+  );
   let messages = {};
 
   try {

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -39,23 +39,38 @@ export default function PrivacyPage() {
       </nav>
 
       {/* Main Content */}
-      <main className="min-h-screen bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-800">
+      <main
+        id="content"
+        tabIndex={-1}
+        className="min-h-screen bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-800"
+      >
         <div className="container mx-auto px-6 py-16">
           <div className="max-w-4xl mx-auto prose prose-lg dark:prose-invert">
             <h1>Privacy Policy</h1>
             <p className="text-gray-600 dark:text-gray-400">
-              <strong>Last Updated:</strong> {new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+              <strong>Last Updated:</strong>{" "}
+              {new Date().toLocaleDateString("en-US", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })}
             </p>
 
             <h2>1. Introduction</h2>
             <p>
-              Welcome to TACTEC ("we," "our," or "us"). We respect your privacy and are committed to protecting your personal data. This privacy policy explains how we collect, use, disclose, and safeguard your information when you visit our website tactec.club.
+              Welcome to TACTEC ("we," "our," or "us"). We respect your privacy
+              and are committed to protecting your personal data. This privacy
+              policy explains how we collect, use, disclose, and safeguard your
+              information when you visit our website tactec.club.
             </p>
 
             <h2>2. Information We Collect</h2>
-            
+
             <h3>2.1 Information You Provide</h3>
-            <p>We collect information that you voluntarily provide to us when you:</p>
+            <p>
+              We collect information that you voluntarily provide to us when
+              you:
+            </p>
             <ul>
               <li>Fill out contact forms</li>
               <li>Request a demo</li>
@@ -73,7 +88,10 @@ export default function PrivacyPage() {
             </ul>
 
             <h3>2.2 Automatically Collected Information</h3>
-            <p>When you visit our website, we automatically collect certain information about your device, including:</p>
+            <p>
+              When you visit our website, we automatically collect certain
+              information about your device, including:
+            </p>
             <ul>
               <li>IP address</li>
               <li>Browser type and version</li>
@@ -86,135 +104,260 @@ export default function PrivacyPage() {
 
             <h3>2.3 Cookies and Tracking Technologies</h3>
             <p>
-              We use cookies and similar tracking technologies to track activity on our website and store certain information. You can instruct your browser to refuse all cookies or to indicate when a cookie is being sent. However, if you do not accept cookies, you may not be able to use some portions of our website.
+              We use cookies and similar tracking technologies to track activity
+              on our website and store certain information. You can instruct
+              your browser to refuse all cookies or to indicate when a cookie is
+              being sent. However, if you do not accept cookies, you may not be
+              able to use some portions of our website.
             </p>
 
             <h2>3. How We Use Your Information</h2>
             <p>We use the collected information for various purposes:</p>
             <ul>
-              <li><strong>To provide and maintain our service</strong></li>
-              <li><strong>To respond to your inquiries</strong> and provide customer support</li>
-              <li><strong>To send you marketing communications</strong> (with your consent)</li>
-              <li><strong>To improve our website</strong> and user experience</li>
-              <li><strong>To analyze usage patterns</strong> and optimize our services</li>
-              <li><strong>To detect and prevent fraud</strong> and security issues</li>
-              <li><strong>To comply with legal obligations</strong></li>
+              <li>
+                <strong>To provide and maintain our service</strong>
+              </li>
+              <li>
+                <strong>To respond to your inquiries</strong> and provide
+                customer support
+              </li>
+              <li>
+                <strong>To send you marketing communications</strong> (with your
+                consent)
+              </li>
+              <li>
+                <strong>To improve our website</strong> and user experience
+              </li>
+              <li>
+                <strong>To analyze usage patterns</strong> and optimize our
+                services
+              </li>
+              <li>
+                <strong>To detect and prevent fraud</strong> and security issues
+              </li>
+              <li>
+                <strong>To comply with legal obligations</strong>
+              </li>
             </ul>
 
             <h2>4. Google Analytics</h2>
             <p>
-              We use Google Analytics to analyze website traffic and usage patterns. Google Analytics uses cookies to collect information about your use of our website. This information is used to compile reports and help us improve our website. The cookies collect information in an anonymous form.
+              We use Google Analytics to analyze website traffic and usage
+              patterns. Google Analytics uses cookies to collect information
+              about your use of our website. This information is used to compile
+              reports and help us improve our website. The cookies collect
+              information in an anonymous form.
             </p>
             <p>
-              You can opt-out of Google Analytics by installing the{' '}
-              <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer">
+              You can opt-out of Google Analytics by installing the{" "}
+              <a
+                href="https://tools.google.com/dlpage/gaoptout"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 Google Analytics Opt-out Browser Add-on
-              </a>.
+              </a>
+              .
             </p>
 
             <h2>5. Legal Basis for Processing (GDPR)</h2>
-            <p>If you are from the European Economic Area (EEA), our legal basis for collecting and using your personal information depends on the data and the context in which we collect it:</p>
+            <p>
+              If you are from the European Economic Area (EEA), our legal basis
+              for collecting and using your personal information depends on the
+              data and the context in which we collect it:
+            </p>
             <ul>
-              <li><strong>Consent:</strong> You have given us permission to process your data for a specific purpose</li>
-              <li><strong>Contract:</strong> Processing is necessary for a contract with you</li>
-              <li><strong>Legal obligation:</strong> We need to comply with the law</li>
-              <li><strong>Legitimate interests:</strong> Processing is in our legitimate interests and doesn't override your rights</li>
+              <li>
+                <strong>Consent:</strong> You have given us permission to
+                process your data for a specific purpose
+              </li>
+              <li>
+                <strong>Contract:</strong> Processing is necessary for a
+                contract with you
+              </li>
+              <li>
+                <strong>Legal obligation:</strong> We need to comply with the
+                law
+              </li>
+              <li>
+                <strong>Legitimate interests:</strong> Processing is in our
+                legitimate interests and doesn't override your rights
+              </li>
             </ul>
 
             <h2>6. Data Retention</h2>
             <p>
-              We retain your personal information only for as long as necessary to fulfill the purposes outlined in this privacy policy, unless a longer retention period is required or permitted by law. When we have no ongoing legitimate business need to process your personal information, we will delete or anonymize it.
+              We retain your personal information only for as long as necessary
+              to fulfill the purposes outlined in this privacy policy, unless a
+              longer retention period is required or permitted by law. When we
+              have no ongoing legitimate business need to process your personal
+              information, we will delete or anonymize it.
             </p>
 
             <h2>7. Data Sharing and Disclosure</h2>
             <p>We may share your information in the following situations:</p>
             <ul>
-              <li><strong>With service providers:</strong> Third-party companies that help us operate our website (e.g., hosting, analytics, email services)</li>
-              <li><strong>For legal reasons:</strong> When required by law or to protect our rights</li>
-              <li><strong>Business transfers:</strong> In connection with a merger, acquisition, or sale of assets</li>
-              <li><strong>With your consent:</strong> When you have given us permission to share your information</li>
+              <li>
+                <strong>With service providers:</strong> Third-party companies
+                that help us operate our website (e.g., hosting, analytics,
+                email services)
+              </li>
+              <li>
+                <strong>For legal reasons:</strong> When required by law or to
+                protect our rights
+              </li>
+              <li>
+                <strong>Business transfers:</strong> In connection with a
+                merger, acquisition, or sale of assets
+              </li>
+              <li>
+                <strong>With your consent:</strong> When you have given us
+                permission to share your information
+              </li>
             </ul>
             <p>
-              <strong>We do not sell your personal information to third parties.</strong>
+              <strong>
+                We do not sell your personal information to third parties.
+              </strong>
             </p>
 
             <h2>8. Your Data Protection Rights</h2>
-            <p>Depending on your location, you may have the following rights:</p>
+            <p>
+              Depending on your location, you may have the following rights:
+            </p>
             <ul>
-              <li><strong>Right to access:</strong> Request copies of your personal data</li>
-              <li><strong>Right to rectification:</strong> Request correction of inaccurate data</li>
-              <li><strong>Right to erasure:</strong> Request deletion of your data</li>
-              <li><strong>Right to restrict processing:</strong> Request limitation on how we use your data</li>
-              <li><strong>Right to data portability:</strong> Request transfer of your data to another organization</li>
-              <li><strong>Right to object:</strong> Object to our processing of your data</li>
-              <li><strong>Right to withdraw consent:</strong> Withdraw consent at any time where we relied on consent</li>
+              <li>
+                <strong>Right to access:</strong> Request copies of your
+                personal data
+              </li>
+              <li>
+                <strong>Right to rectification:</strong> Request correction of
+                inaccurate data
+              </li>
+              <li>
+                <strong>Right to erasure:</strong> Request deletion of your data
+              </li>
+              <li>
+                <strong>Right to restrict processing:</strong> Request
+                limitation on how we use your data
+              </li>
+              <li>
+                <strong>Right to data portability:</strong> Request transfer of
+                your data to another organization
+              </li>
+              <li>
+                <strong>Right to object:</strong> Object to our processing of
+                your data
+              </li>
+              <li>
+                <strong>Right to withdraw consent:</strong> Withdraw consent at
+                any time where we relied on consent
+              </li>
             </ul>
             <p>
-              To exercise these rights, please contact us at{' '}
+              To exercise these rights, please contact us at{" "}
               <a href="mailto:privacy@tactec.club">privacy@tactec.club</a>
             </p>
 
             <h2>9. International Data Transfers</h2>
             <p>
-              Your information may be transferred to and maintained on computers located outside of your state, province, country, or other governmental jurisdiction where data protection laws may differ. We will take all steps reasonably necessary to ensure that your data is treated securely and in accordance with this privacy policy.
+              Your information may be transferred to and maintained on computers
+              located outside of your state, province, country, or other
+              governmental jurisdiction where data protection laws may differ.
+              We will take all steps reasonably necessary to ensure that your
+              data is treated securely and in accordance with this privacy
+              policy.
             </p>
 
             <h2>10. Security</h2>
             <p>
-              We implement appropriate technical and organizational security measures to protect your personal information. However, no method of transmission over the Internet or electronic storage is 100% secure, and we cannot guarantee absolute security.
+              We implement appropriate technical and organizational security
+              measures to protect your personal information. However, no method
+              of transmission over the Internet or electronic storage is 100%
+              secure, and we cannot guarantee absolute security.
             </p>
 
             <h2>11. Children's Privacy</h2>
             <p>
-              Our website is not intended for children under the age of 16. We do not knowingly collect personal information from children under 16. If you are a parent or guardian and believe your child has provided us with personal information, please contact us.
+              Our website is not intended for children under the age of 16. We
+              do not knowingly collect personal information from children under
+              16. If you are a parent or guardian and believe your child has
+              provided us with personal information, please contact us.
             </p>
 
             <h2>12. Third-Party Links</h2>
             <p>
-              Our website may contain links to third-party websites. We are not responsible for the privacy practices of these external sites. We encourage you to read their privacy policies.
+              Our website may contain links to third-party websites. We are not
+              responsible for the privacy practices of these external sites. We
+              encourage you to read their privacy policies.
             </p>
 
             <h2>13. Changes to This Privacy Policy</h2>
             <p>
-              We may update this privacy policy from time to time. We will notify you of any changes by posting the new privacy policy on this page and updating the "Last Updated" date. You are advised to review this privacy policy periodically for any changes.
+              We may update this privacy policy from time to time. We will
+              notify you of any changes by posting the new privacy policy on
+              this page and updating the "Last Updated" date. You are advised to
+              review this privacy policy periodically for any changes.
             </p>
 
             <h2>14. Contact Us</h2>
-            <p>If you have any questions about this privacy policy, please contact us:</p>
+            <p>
+              If you have any questions about this privacy policy, please
+              contact us:
+            </p>
             <ul>
-              <li><strong>Email:</strong> <a href="mailto:privacy@tactec.club">privacy@tactec.club</a></li>
-              <li><strong>Website:</strong> <a href="https://tactec.club/contact">https://tactec.club/contact</a></li>
+              <li>
+                <strong>Email:</strong>{" "}
+                <a href="mailto:privacy@tactec.club">privacy@tactec.club</a>
+              </li>
+              <li>
+                <strong>Website:</strong>{" "}
+                <a href="https://tactec.club/contact">
+                  https://tactec.club/contact
+                </a>
+              </li>
             </ul>
 
             <h2>15. Cookie Policy</h2>
-            
+
             <h3>15.1 What Are Cookies?</h3>
             <p>
-              Cookies are small text files that are placed on your device when you visit our website. They help us provide you with a better experience by remembering your preferences and understanding how you use our site.
+              Cookies are small text files that are placed on your device when
+              you visit our website. They help us provide you with a better
+              experience by remembering your preferences and understanding how
+              you use our site.
             </p>
 
             <h3>15.2 Types of Cookies We Use</h3>
             <ul>
               <li>
-                <strong>Essential Cookies:</strong> Required for the website to function properly
+                <strong>Essential Cookies:</strong> Required for the website to
+                function properly
               </li>
               <li>
-                <strong>Analytics Cookies:</strong> Help us understand how visitors use our website (Google Analytics)
+                <strong>Analytics Cookies:</strong> Help us understand how
+                visitors use our website (Google Analytics)
               </li>
               <li>
-                <strong>Preference Cookies:</strong> Remember your settings and preferences
+                <strong>Preference Cookies:</strong> Remember your settings and
+                preferences
               </li>
             </ul>
 
             <h3>15.3 Managing Cookies</h3>
             <p>
-              You can control and manage cookies through our cookie consent banner or your browser settings. Please note that disabling certain cookies may affect the functionality of our website.
+              You can control and manage cookies through our cookie consent
+              banner or your browser settings. Please note that disabling
+              certain cookies may affect the functionality of our website.
             </p>
 
             <div className="mt-12 p-6 bg-sky-50 dark:bg-sky-900/20 rounded-lg border border-sky-200 dark:border-sky-800">
-              <h3 className="text-sky-900 dark:text-sky-100 mt-0">Need More Information?</h3>
+              <h3 className="text-sky-900 dark:text-sky-100 mt-0">
+                Need More Information?
+              </h3>
               <p className="mb-4">
-                If you have questions about our privacy practices or want to exercise your data rights, we're here to help.
+                If you have questions about our privacy practices or want to
+                exercise your data rights, we're here to help.
               </p>
               <Link
                 href="/contact"
@@ -231,7 +374,9 @@ export default function PrivacyPage() {
       <footer className="bg-gray-900 text-gray-400 py-8">
         <div className="container mx-auto px-6 text-center">
           <p className="text-sm">© Ventio. All rights reserved.</p>
-          <p className="mt-2 text-sky-400 text-sm">Made with care for football.</p>
+          <p className="mt-2 text-sky-400 text-sm">
+            Made with care for football.
+          </p>
         </div>
       </footer>
     </>
@@ -242,8 +387,18 @@ export async function getStaticProps({ locale }: { locale: string }) {
   const fs = await import("fs");
   const path = await import("path");
 
-  const filePath = path.join(process.cwd(), "src/locales", locale, "common.json");
-  const fallbackPath = path.join(process.cwd(), "src/locales", "en", "common.json");
+  const filePath = path.join(
+    process.cwd(),
+    "src/locales",
+    locale,
+    "common.json",
+  );
+  const fallbackPath = path.join(
+    process.cwd(),
+    "src/locales",
+    "en",
+    "common.json",
+  );
   let messages = {};
 
   try {


### PR DESCRIPTION
## Summary
- wrap the landing page sections in a `<main id="content" tabIndex={-1}>` container so the global skip link lands on the primary content
- add the same `id="content"` and focusable behavior to the contact and privacy pages for consistent keyboard navigation support

## Testing
- Manual: Verified the "Skip to content" link moves focus to the main content using keyboard navigation


------
https://chatgpt.com/codex/tasks/task_e_68dc1dec1abc832a985c9906267f2ba6