### PR TITLE
Fix locale switcher and wire skip link

### DIFF
--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -15,7 +15,7 @@ const locales = [
 ];
 
 export default function LanguageSwitcher() {
-  const { locale, pathname, asPath, query } = useRouter();
+  const { locale, pathname, query } = useRouter();
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -93,7 +93,6 @@ export default function LanguageSwitcher() {
               <Link
                 key={l.code}
                 href={{ pathname, query }}
-                as={asPath}
                 locale={l.code}
                 onClick={() => handleLanguageChange(l.code)}
                 className={`block px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors ${
@@ -118,10 +117,9 @@ export default function LanguageSwitcher() {
         aria-label="Language selection"
       >
         {locales.map(l => (
-          <Link 
-            key={l.code} 
-            href={{ pathname, query }} 
-            as={asPath} 
+          <Link
+            key={l.code}
+            href={{ pathname, query }}
             locale={l.code}
             onClick={() => handleLanguageChange(l.code)}
             className={`px-2 py-1 hover:bg-gray-100 dark:hover:bg-gray-900 transition-colors ${

--- a/src/components/TacTecLanding.tsx
+++ b/src/components/TacTecLanding.tsx
@@ -51,8 +51,9 @@ export default function TacTecLanding() {
         </div>
       </nav>
 
-      {/* Hero Section */}
-      <section className="relative bg-gradient-to-b from-gray-50 to-white dark:from-gray-900 dark:to-gray-800 py-20">
+      <main id="content">
+        {/* Hero Section */}
+        <section className="relative bg-gradient-to-b from-gray-50 to-white dark:from-gray-900 dark:to-gray-800 py-20">
         <div className="container mx-auto px-6">
           <div className="max-w-4xl mx-auto text-center">
             <p className="text-sky-600 font-semibold mb-4">{t('hero.trusted')}</p>
@@ -94,10 +95,10 @@ export default function TacTecLanding() {
             </div>
           </div>
         </div>
-      </section>
+        </section>
 
-      {/* Challenge Section */}
-      <section id="challenge" className="py-20 bg-white dark:bg-gray-900">
+        {/* Challenge Section */}
+        <section id="challenge" className="py-20 bg-white dark:bg-gray-900">
         <div className="container mx-auto px-6">
           <div className="max-w-4xl mx-auto text-center mb-16">
             <p className="text-sky-600 font-semibold mb-4">{t('challenge.eyebrow')}</p>
@@ -127,10 +128,10 @@ export default function TacTecLanding() {
             />
           </div>
         </div>
-      </section>
+        </section>
 
-      {/* Solution Section */}
-      <section id="solution" className="py-20 bg-gray-50 dark:bg-gray-800">
+        {/* Solution Section */}
+        <section id="solution" className="py-20 bg-gray-50 dark:bg-gray-800">
         <div className="container mx-auto px-6">
           <div className="max-w-4xl mx-auto text-center">
             <p className="text-sky-600 font-semibold mb-4">{t('solution.eyebrow')}</p>
@@ -138,10 +139,10 @@ export default function TacTecLanding() {
             <p className="text-xl text-gray-600 dark:text-gray-400">{t('solution.subtitle')}</p>
           </div>
         </div>
-      </section>
+        </section>
 
-      {/* Features Section */}
-      <section id="features" className="py-20 bg-white dark:bg-gray-900">
+        {/* Features Section */}
+        <section id="features" className="py-20 bg-white dark:bg-gray-900">
         <div className="container mx-auto px-6">
           <div className="max-w-4xl mx-auto text-center">
             <p className="text-sky-600 font-semibold mb-4">{t('features.eyebrow')}</p>
@@ -149,10 +150,10 @@ export default function TacTecLanding() {
             <p className="text-xl text-gray-600 dark:text-gray-400">{t('features.subtitle')}</p>
           </div>
         </div>
-      </section>
+        </section>
 
-      {/* Tech Section */}
-      <section id="tech" className="py-20 bg-gray-50 dark:bg-gray-800">
+        {/* Tech Section */}
+        <section id="tech" className="py-20 bg-gray-50 dark:bg-gray-800">
         <div className="container mx-auto px-6">
           <div className="max-w-4xl mx-auto text-center">
             <p className="text-sky-600 font-semibold mb-4">{t('tech.eyebrow')}</p>
@@ -160,10 +161,10 @@ export default function TacTecLanding() {
             <p className="text-xl text-gray-600 dark:text-gray-400">{t('tech.subtitle')}</p>
           </div>
         </div>
-      </section>
+        </section>
 
-      {/* CTA Section */}
-      <section id="demo" className="py-20 bg-sky-600 text-white">
+        {/* CTA Section */}
+        <section id="demo" className="py-20 bg-sky-600 text-white">
         <div className="container mx-auto px-6">
           <div className="max-w-4xl mx-auto text-center">
             <p className="font-semibold mb-4">{t('cta.eyebrow')}</p>
@@ -180,7 +181,8 @@ export default function TacTecLanding() {
             </div>
           </div>
         </div>
-      </section>
+        </section>
+      </main>
 
       {/* Footer */}
       <footer className="bg-gray-900 text-gray-400 py-12">

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -157,7 +157,10 @@ export default function ContactPage() {
       </nav>
 
       {/* Page Content */}
-      <main className="min-h-screen bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-800">
+      <main
+        id="content"
+        className="min-h-screen bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-800"
+      >
         <div className="container mx-auto px-6 py-16">
           <div className="max-w-4xl mx-auto">
             {/* Header */}

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -39,7 +39,10 @@ export default function PrivacyPage() {
       </nav>
 
       {/* Main Content */}
-      <main className="min-h-screen bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-800">
+      <main
+        id="content"
+        className="min-h-screen bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-800"
+      >
         <div className="container mx-auto px-6 py-16">
           <div className="max-w-4xl mx-auto prose prose-lg dark:prose-invert">
             <h1>Privacy Policy</h1>


### PR DESCRIPTION
## Summary
- remove the `as` prop from language switcher links so locale changes use Next.js routing
- add `id="content"` main wrappers on the landing, contact, and privacy pages to give the skip link a valid destination

## Testing
- not run (interactive eslint prompt prevents automated execution)


------
https://chatgpt.com/codex/tasks/task_e_68dc1c020f08832a9d5eecb72f14ad79