### PR TITLE
Update manifest screenshots to existing assets

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -12,18 +12,18 @@
   "categories": ["sports", "business", "productivity"],
   "screenshots": [
     {
-      "src": "/images/screenshot-mobile.webp",
-      "sizes": "390x844",
+      "src": "/images/1000286398.webp",
+      "sizes": "301x653",
       "type": "image/webp",
       "form_factor": "narrow",
-      "label": "TACTEC Mobile Experience"
+      "label": "TACTEC Mobile Interface"
     },
     {
-      "src": "/images/screenshot-desktop.webp", 
+      "src": "/images/Client_Offering_Catalog1.webp",
       "sizes": "1920x1080",
       "type": "image/webp",
       "form_factor": "wide",
-      "label": "TACTEC Desktop Experience"
+      "label": "TACTEC Platform Overview"
     }
   ],
   "icons": [

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -15,7 +15,7 @@ const locales = [
 ];
 
 export default function LanguageSwitcher() {
-  const { locale, pathname, asPath, query } = useRouter();
+  const { locale, pathname, query } = useRouter();
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 


### PR DESCRIPTION
## Summary
- point the manifest screenshot entries to existing images in `public/images` with accurate dimensions and labels
- remove the unused `asPath` destructure from the language switcher to keep the build passing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc249576e0832aa20d547b27f10229