### PR TITLE
Fix unused variable in language switcher

### DIFF
--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -15,7 +15,7 @@ const locales = [
 ];
 
 export default function LanguageSwitcher() {
-  const { locale, pathname, asPath, query } = useRouter();
+  const { locale, pathname, query } = useRouter();
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 


### PR DESCRIPTION
## Summary
- remove the unused `asPath` property from the router destructuring in `LanguageSwitcher`

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc253b5de0832aa1e248bdafcde148