### PR TITLE
Document rationale for omitting asPath in language switcher

### DIFF
--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -15,6 +15,8 @@ const locales = [
 ];
 
 export default function LanguageSwitcher() {
+  // Note: `asPath` is intentionally not destructured because the localized
+  // links are generated from the pathname/query combination.
   const { locale, pathname, query } = useRouter();
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
## Summary
- add a clarifying comment to the language switcher explaining why `asPath` is not destructured from the router

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68dc27005648832a8c43a9d7088f7be0