### PR TITLE
Localize contact page copy and validation

### DIFF
--- a/src/locales/ar/common.json
+++ b/src/locales/ar/common.json
@@ -82,5 +82,84 @@
     "a2": "نعم. تدعم الواجهة العربية والبرتغالية (الأوروبية) والبرتغالية البرازيلية والإسبانية والفرنسية والإيطالية والألمانية والإنجليزية.",
     "q3": "كيف نبدأ؟",
     "a3": "اتصل بنا للحصول على عرض توضيحي مباشر وخطة تأهيل."
+  },
+  "contact": {
+    "meta": {
+      "title": "Contact - TACTEC",
+      "description": "Get in touch with TACTEC team for demos and inquiries. Transform your football club operations with our professional platform.",
+      "ogTitle": "Contact TACTEC - Football Club Management Platform",
+      "ogDescription": "Request a demo or get in touch with our team to learn how TACTEC can transform your club operations."
+    },
+    "nav": {
+      "back": "← Back to Home"
+    },
+    "header": {
+      "title": "Get in Touch",
+      "subtitle": "Ready to transform your club? Request a demo or contact our team."
+    },
+    "form": {
+      "requestType": {
+        "label": "Request Type *",
+        "options": {
+          "demo": "Request Demo",
+          "sales": "Sales Inquiry",
+          "support": "Support",
+          "general": "General Question"
+        }
+      },
+      "name": {
+        "label": "Your Name *",
+        "placeholder": "John Doe"
+      },
+      "email": {
+        "label": "Email Address *",
+        "placeholder": "john@club.com"
+      },
+      "club": {
+        "label": "Club/Organization *",
+        "placeholder": "FC Example"
+      },
+      "role": {
+        "label": "Your Role *",
+        "placeholder": "Manager, Coach, Director, etc."
+      },
+      "message": {
+        "label": "Message *",
+        "placeholder": "Tell us about your needs..."
+      },
+      "submit": {
+        "default": "Send Message",
+        "loading": "Sending..."
+      }
+    },
+    "status": {
+      "success": "Your message has been sent successfully!",
+      "error": "Something went wrong. Please try again or email us directly.",
+      "apiDefaults": {
+        "success": "Your message has been sent successfully!",
+        "error": "Failed to send message"
+      }
+    },
+    "info": {
+      "email": {
+        "label": "Email",
+        "value": "info@tactec.club"
+      },
+      "response": {
+        "label": "Response Time",
+        "value": "Within 24 hours"
+      },
+      "languages": {
+        "label": "Languages",
+        "value": "8 languages supported"
+      }
+    },
+    "validation": {
+      "nameMin": "Name must be at least 2 characters",
+      "email": "Please enter a valid email address",
+      "clubMin": "Club name must be at least 2 characters",
+      "roleMin": "Please select your role",
+      "messageMin": "Message must be at least 10 characters"
+    }
   }
 }

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -82,5 +82,84 @@
     "a2": "Ja. Die Benutzeroberfläche unterstützt Arabisch, Portugiesisch (EU), brasilianisches Portugiesisch, Spanisch, Französisch, Italienisch, Deutsch und Englisch.",
     "q3": "Wie fangen wir an?",
     "a3": "Kontaktieren Sie uns für eine Live-Demo und einen Onboarding-Plan."
+  },
+  "contact": {
+    "meta": {
+      "title": "Contact - TACTEC",
+      "description": "Get in touch with TACTEC team for demos and inquiries. Transform your football club operations with our professional platform.",
+      "ogTitle": "Contact TACTEC - Football Club Management Platform",
+      "ogDescription": "Request a demo or get in touch with our team to learn how TACTEC can transform your club operations."
+    },
+    "nav": {
+      "back": "← Back to Home"
+    },
+    "header": {
+      "title": "Get in Touch",
+      "subtitle": "Ready to transform your club? Request a demo or contact our team."
+    },
+    "form": {
+      "requestType": {
+        "label": "Request Type *",
+        "options": {
+          "demo": "Request Demo",
+          "sales": "Sales Inquiry",
+          "support": "Support",
+          "general": "General Question"
+        }
+      },
+      "name": {
+        "label": "Your Name *",
+        "placeholder": "John Doe"
+      },
+      "email": {
+        "label": "Email Address *",
+        "placeholder": "john@club.com"
+      },
+      "club": {
+        "label": "Club/Organization *",
+        "placeholder": "FC Example"
+      },
+      "role": {
+        "label": "Your Role *",
+        "placeholder": "Manager, Coach, Director, etc."
+      },
+      "message": {
+        "label": "Message *",
+        "placeholder": "Tell us about your needs..."
+      },
+      "submit": {
+        "default": "Send Message",
+        "loading": "Sending..."
+      }
+    },
+    "status": {
+      "success": "Your message has been sent successfully!",
+      "error": "Something went wrong. Please try again or email us directly.",
+      "apiDefaults": {
+        "success": "Your message has been sent successfully!",
+        "error": "Failed to send message"
+      }
+    },
+    "info": {
+      "email": {
+        "label": "Email",
+        "value": "info@tactec.club"
+      },
+      "response": {
+        "label": "Response Time",
+        "value": "Within 24 hours"
+      },
+      "languages": {
+        "label": "Languages",
+        "value": "8 languages supported"
+      }
+    },
+    "validation": {
+      "nameMin": "Name must be at least 2 characters",
+      "email": "Please enter a valid email address",
+      "clubMin": "Club name must be at least 2 characters",
+      "roleMin": "Please select your role",
+      "messageMin": "Message must be at least 10 characters"
+    }
   }
 }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -82,5 +82,84 @@
     "a2": "Yes. The interface supports Arabic, Portuguese (EU), Brazilian Portuguese, Spanish, French, Italian, German, and English.",
     "q3": "How do we get started?",
     "a3": "Contact us for a live demo and onboarding plan."
+  },
+  "contact": {
+    "meta": {
+      "title": "Contact - TACTEC",
+      "description": "Get in touch with TACTEC team for demos and inquiries. Transform your football club operations with our professional platform.",
+      "ogTitle": "Contact TACTEC - Football Club Management Platform",
+      "ogDescription": "Request a demo or get in touch with our team to learn how TACTEC can transform your club operations."
+    },
+    "nav": {
+      "back": "← Back to Home"
+    },
+    "header": {
+      "title": "Get in Touch",
+      "subtitle": "Ready to transform your club? Request a demo or contact our team."
+    },
+    "form": {
+      "requestType": {
+        "label": "Request Type *",
+        "options": {
+          "demo": "Request Demo",
+          "sales": "Sales Inquiry",
+          "support": "Support",
+          "general": "General Question"
+        }
+      },
+      "name": {
+        "label": "Your Name *",
+        "placeholder": "John Doe"
+      },
+      "email": {
+        "label": "Email Address *",
+        "placeholder": "john@club.com"
+      },
+      "club": {
+        "label": "Club/Organization *",
+        "placeholder": "FC Example"
+      },
+      "role": {
+        "label": "Your Role *",
+        "placeholder": "Manager, Coach, Director, etc."
+      },
+      "message": {
+        "label": "Message *",
+        "placeholder": "Tell us about your needs..."
+      },
+      "submit": {
+        "default": "Send Message",
+        "loading": "Sending..."
+      }
+    },
+    "status": {
+      "success": "Your message has been sent successfully!",
+      "error": "Something went wrong. Please try again or email us directly.",
+      "apiDefaults": {
+        "success": "Your message has been sent successfully!",
+        "error": "Failed to send message"
+      }
+    },
+    "info": {
+      "email": {
+        "label": "Email",
+        "value": "info@tactec.club"
+      },
+      "response": {
+        "label": "Response Time",
+        "value": "Within 24 hours"
+      },
+      "languages": {
+        "label": "Languages",
+        "value": "8 languages supported"
+      }
+    },
+    "validation": {
+      "nameMin": "Name must be at least 2 characters",
+      "email": "Please enter a valid email address",
+      "clubMin": "Club name must be at least 2 characters",
+      "roleMin": "Please select your role",
+      "messageMin": "Message must be at least 10 characters"
+    }
   }
 }

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -82,5 +82,84 @@
     "a2": "Sí. La interfaz admite árabe, portugués (UE), portugués brasileño, español, francés, italiano, alemán e inglés.",
     "q3": "¿Cómo empezar?",
     "a3": "Contáctenos para una demostración en vivo y un plan de incorporación."
+  },
+  "contact": {
+    "meta": {
+      "title": "Contact - TACTEC",
+      "description": "Get in touch with TACTEC team for demos and inquiries. Transform your football club operations with our professional platform.",
+      "ogTitle": "Contact TACTEC - Football Club Management Platform",
+      "ogDescription": "Request a demo or get in touch with our team to learn how TACTEC can transform your club operations."
+    },
+    "nav": {
+      "back": "← Back to Home"
+    },
+    "header": {
+      "title": "Get in Touch",
+      "subtitle": "Ready to transform your club? Request a demo or contact our team."
+    },
+    "form": {
+      "requestType": {
+        "label": "Request Type *",
+        "options": {
+          "demo": "Request Demo",
+          "sales": "Sales Inquiry",
+          "support": "Support",
+          "general": "General Question"
+        }
+      },
+      "name": {
+        "label": "Your Name *",
+        "placeholder": "John Doe"
+      },
+      "email": {
+        "label": "Email Address *",
+        "placeholder": "john@club.com"
+      },
+      "club": {
+        "label": "Club/Organization *",
+        "placeholder": "FC Example"
+      },
+      "role": {
+        "label": "Your Role *",
+        "placeholder": "Manager, Coach, Director, etc."
+      },
+      "message": {
+        "label": "Message *",
+        "placeholder": "Tell us about your needs..."
+      },
+      "submit": {
+        "default": "Send Message",
+        "loading": "Sending..."
+      }
+    },
+    "status": {
+      "success": "Your message has been sent successfully!",
+      "error": "Something went wrong. Please try again or email us directly.",
+      "apiDefaults": {
+        "success": "Your message has been sent successfully!",
+        "error": "Failed to send message"
+      }
+    },
+    "info": {
+      "email": {
+        "label": "Email",
+        "value": "info@tactec.club"
+      },
+      "response": {
+        "label": "Response Time",
+        "value": "Within 24 hours"
+      },
+      "languages": {
+        "label": "Languages",
+        "value": "8 languages supported"
+      }
+    },
+    "validation": {
+      "nameMin": "Name must be at least 2 characters",
+      "email": "Please enter a valid email address",
+      "clubMin": "Club name must be at least 2 characters",
+      "roleMin": "Please select your role",
+      "messageMin": "Message must be at least 10 characters"
+    }
   }
 }

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -82,5 +82,84 @@
     "a2": "Oui. L'interface prend en charge l'arabe, le portugais (UE), le portugais brésilien, l'espagnol, le français, l'italien, l'allemand et l'anglais.",
     "q3": "Comment commencer?",
     "a3": "Contactez-nous pour une démo en direct et un plan d'intégration."
+  },
+  "contact": {
+    "meta": {
+      "title": "Contact - TACTEC",
+      "description": "Get in touch with TACTEC team for demos and inquiries. Transform your football club operations with our professional platform.",
+      "ogTitle": "Contact TACTEC - Football Club Management Platform",
+      "ogDescription": "Request a demo or get in touch with our team to learn how TACTEC can transform your club operations."
+    },
+    "nav": {
+      "back": "← Back to Home"
+    },
+    "header": {
+      "title": "Get in Touch",
+      "subtitle": "Ready to transform your club? Request a demo or contact our team."
+    },
+    "form": {
+      "requestType": {
+        "label": "Request Type *",
+        "options": {
+          "demo": "Request Demo",
+          "sales": "Sales Inquiry",
+          "support": "Support",
+          "general": "General Question"
+        }
+      },
+      "name": {
+        "label": "Your Name *",
+        "placeholder": "John Doe"
+      },
+      "email": {
+        "label": "Email Address *",
+        "placeholder": "john@club.com"
+      },
+      "club": {
+        "label": "Club/Organization *",
+        "placeholder": "FC Example"
+      },
+      "role": {
+        "label": "Your Role *",
+        "placeholder": "Manager, Coach, Director, etc."
+      },
+      "message": {
+        "label": "Message *",
+        "placeholder": "Tell us about your needs..."
+      },
+      "submit": {
+        "default": "Send Message",
+        "loading": "Sending..."
+      }
+    },
+    "status": {
+      "success": "Your message has been sent successfully!",
+      "error": "Something went wrong. Please try again or email us directly.",
+      "apiDefaults": {
+        "success": "Your message has been sent successfully!",
+        "error": "Failed to send message"
+      }
+    },
+    "info": {
+      "email": {
+        "label": "Email",
+        "value": "info@tactec.club"
+      },
+      "response": {
+        "label": "Response Time",
+        "value": "Within 24 hours"
+      },
+      "languages": {
+        "label": "Languages",
+        "value": "8 languages supported"
+      }
+    },
+    "validation": {
+      "nameMin": "Name must be at least 2 characters",
+      "email": "Please enter a valid email address",
+      "clubMin": "Club name must be at least 2 characters",
+      "roleMin": "Please select your role",
+      "messageMin": "Message must be at least 10 characters"
+    }
   }
 }

--- a/src/locales/it/common.json
+++ b/src/locales/it/common.json
@@ -82,5 +82,84 @@
     "a2": "Sì. L'interfaccia supporta arabo, portoghese (UE), portoghese brasiliano, spagnolo, francese, italiano, tedesco e inglese.",
     "q3": "Come iniziare?",
     "a3": "Contattaci per una demo dal vivo e un piano di onboarding."
+  },
+  "contact": {
+    "meta": {
+      "title": "Contact - TACTEC",
+      "description": "Get in touch with TACTEC team for demos and inquiries. Transform your football club operations with our professional platform.",
+      "ogTitle": "Contact TACTEC - Football Club Management Platform",
+      "ogDescription": "Request a demo or get in touch with our team to learn how TACTEC can transform your club operations."
+    },
+    "nav": {
+      "back": "← Back to Home"
+    },
+    "header": {
+      "title": "Get in Touch",
+      "subtitle": "Ready to transform your club? Request a demo or contact our team."
+    },
+    "form": {
+      "requestType": {
+        "label": "Request Type *",
+        "options": {
+          "demo": "Request Demo",
+          "sales": "Sales Inquiry",
+          "support": "Support",
+          "general": "General Question"
+        }
+      },
+      "name": {
+        "label": "Your Name *",
+        "placeholder": "John Doe"
+      },
+      "email": {
+        "label": "Email Address *",
+        "placeholder": "john@club.com"
+      },
+      "club": {
+        "label": "Club/Organization *",
+        "placeholder": "FC Example"
+      },
+      "role": {
+        "label": "Your Role *",
+        "placeholder": "Manager, Coach, Director, etc."
+      },
+      "message": {
+        "label": "Message *",
+        "placeholder": "Tell us about your needs..."
+      },
+      "submit": {
+        "default": "Send Message",
+        "loading": "Sending..."
+      }
+    },
+    "status": {
+      "success": "Your message has been sent successfully!",
+      "error": "Something went wrong. Please try again or email us directly.",
+      "apiDefaults": {
+        "success": "Your message has been sent successfully!",
+        "error": "Failed to send message"
+      }
+    },
+    "info": {
+      "email": {
+        "label": "Email",
+        "value": "info@tactec.club"
+      },
+      "response": {
+        "label": "Response Time",
+        "value": "Within 24 hours"
+      },
+      "languages": {
+        "label": "Languages",
+        "value": "8 languages supported"
+      }
+    },
+    "validation": {
+      "nameMin": "Name must be at least 2 characters",
+      "email": "Please enter a valid email address",
+      "clubMin": "Club name must be at least 2 characters",
+      "roleMin": "Please select your role",
+      "messageMin": "Message must be at least 10 characters"
+    }
   }
 }

--- a/src/locales/pt-BR/common.json
+++ b/src/locales/pt-BR/common.json
@@ -82,5 +82,84 @@
     "a2": "Sim. A interface suporta Árabe, Português (EU), Português do Brasil, Espanhol, Francês, Italiano, Alemão e Inglês.",
     "q3": "Como começar?",
     "a3": "Contacte-nos para uma demonstração ao vivo e um plano de integração."
+  },
+  "contact": {
+    "meta": {
+      "title": "Contact - TACTEC",
+      "description": "Get in touch with TACTEC team for demos and inquiries. Transform your football club operations with our professional platform.",
+      "ogTitle": "Contact TACTEC - Football Club Management Platform",
+      "ogDescription": "Request a demo or get in touch with our team to learn how TACTEC can transform your club operations."
+    },
+    "nav": {
+      "back": "← Back to Home"
+    },
+    "header": {
+      "title": "Get in Touch",
+      "subtitle": "Ready to transform your club? Request a demo or contact our team."
+    },
+    "form": {
+      "requestType": {
+        "label": "Request Type *",
+        "options": {
+          "demo": "Request Demo",
+          "sales": "Sales Inquiry",
+          "support": "Support",
+          "general": "General Question"
+        }
+      },
+      "name": {
+        "label": "Your Name *",
+        "placeholder": "John Doe"
+      },
+      "email": {
+        "label": "Email Address *",
+        "placeholder": "john@club.com"
+      },
+      "club": {
+        "label": "Club/Organization *",
+        "placeholder": "FC Example"
+      },
+      "role": {
+        "label": "Your Role *",
+        "placeholder": "Manager, Coach, Director, etc."
+      },
+      "message": {
+        "label": "Message *",
+        "placeholder": "Tell us about your needs..."
+      },
+      "submit": {
+        "default": "Send Message",
+        "loading": "Sending..."
+      }
+    },
+    "status": {
+      "success": "Your message has been sent successfully!",
+      "error": "Something went wrong. Please try again or email us directly.",
+      "apiDefaults": {
+        "success": "Your message has been sent successfully!",
+        "error": "Failed to send message"
+      }
+    },
+    "info": {
+      "email": {
+        "label": "Email",
+        "value": "info@tactec.club"
+      },
+      "response": {
+        "label": "Response Time",
+        "value": "Within 24 hours"
+      },
+      "languages": {
+        "label": "Languages",
+        "value": "8 languages supported"
+      }
+    },
+    "validation": {
+      "nameMin": "Name must be at least 2 characters",
+      "email": "Please enter a valid email address",
+      "clubMin": "Club name must be at least 2 characters",
+      "roleMin": "Please select your role",
+      "messageMin": "Message must be at least 10 characters"
+    }
   }
 }

--- a/src/locales/pt/common.json
+++ b/src/locales/pt/common.json
@@ -82,5 +82,84 @@
     "a2": "Sim. A interface suporta Árabe, Português (EU), Português do Brasil, Espanhol, Francês, Italiano, Alemão e Inglês.",
     "q3": "Como começar?",
     "a3": "Contacte-nos para uma demonstração ao vivo e um plano de integração."
+  },
+  "contact": {
+    "meta": {
+      "title": "Contact - TACTEC",
+      "description": "Get in touch with TACTEC team for demos and inquiries. Transform your football club operations with our professional platform.",
+      "ogTitle": "Contact TACTEC - Football Club Management Platform",
+      "ogDescription": "Request a demo or get in touch with our team to learn how TACTEC can transform your club operations."
+    },
+    "nav": {
+      "back": "← Back to Home"
+    },
+    "header": {
+      "title": "Get in Touch",
+      "subtitle": "Ready to transform your club? Request a demo or contact our team."
+    },
+    "form": {
+      "requestType": {
+        "label": "Request Type *",
+        "options": {
+          "demo": "Request Demo",
+          "sales": "Sales Inquiry",
+          "support": "Support",
+          "general": "General Question"
+        }
+      },
+      "name": {
+        "label": "Your Name *",
+        "placeholder": "John Doe"
+      },
+      "email": {
+        "label": "Email Address *",
+        "placeholder": "john@club.com"
+      },
+      "club": {
+        "label": "Club/Organization *",
+        "placeholder": "FC Example"
+      },
+      "role": {
+        "label": "Your Role *",
+        "placeholder": "Manager, Coach, Director, etc."
+      },
+      "message": {
+        "label": "Message *",
+        "placeholder": "Tell us about your needs..."
+      },
+      "submit": {
+        "default": "Send Message",
+        "loading": "Sending..."
+      }
+    },
+    "status": {
+      "success": "Your message has been sent successfully!",
+      "error": "Something went wrong. Please try again or email us directly.",
+      "apiDefaults": {
+        "success": "Your message has been sent successfully!",
+        "error": "Failed to send message"
+      }
+    },
+    "info": {
+      "email": {
+        "label": "Email",
+        "value": "info@tactec.club"
+      },
+      "response": {
+        "label": "Response Time",
+        "value": "Within 24 hours"
+      },
+      "languages": {
+        "label": "Languages",
+        "value": "8 languages supported"
+      }
+    },
+    "validation": {
+      "nameMin": "Name must be at least 2 characters",
+      "email": "Please enter a valid email address",
+      "clubMin": "Club name must be at least 2 characters",
+      "roleMin": "Please select your role",
+      "messageMin": "Message must be at least 10 characters"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add localized contact section entries to every locale common.json file
- rebuild the contact form schema inside the page so validation uses translated messages
- replace hard-coded UI and status copy with translations and localize API feedback handling

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc2d121e34832a8fdacce2dae7d855