### PR TITLE
Fix language switcher locale URLs

### DIFF
--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -93,7 +93,6 @@ export default function LanguageSwitcher() {
               <Link
                 key={l.code}
                 href={{ pathname, query }}
-                as={asPath}
                 locale={l.code}
                 onClick={() => handleLanguageChange(l.code)}
                 className={`block px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors ${
@@ -118,10 +117,9 @@ export default function LanguageSwitcher() {
         aria-label="Language selection"
       >
         {locales.map(l => (
-          <Link 
-            key={l.code} 
-            href={{ pathname, query }} 
-            as={asPath} 
+          <Link
+            key={l.code}
+            href={{ pathname, query }}
             locale={l.code}
             onClick={() => handleLanguageChange(l.code)}
             className={`px-2 py-1 hover:bg-gray-100 dark:hover:bg-gray-900 transition-colors ${


### PR DESCRIPTION
## Summary
- remove the asPath override from LanguageSwitcher links so Next.js can generate locale-prefixed URLs automatically

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68dc23b01700832a9915a4b606a59a11