### PR TITLE
Harden contact API protections

### DIFF
--- a/env_example
+++ b/env_example
@@ -53,3 +53,15 @@ NEXT_PUBLIC_ERROR_ENDPOINT=
 
 # Set to 'true' to test error reporting
 # TEST_ERROR_REPORTING=false
+
+# --------------------------------------------
+# Infrastructure
+# --------------------------------------------
+# Comma separated list of proxy IPs that are allowed to forward client addresses
+# Example: TRUSTED_PROXY_IPS=127.0.0.1,10.0.0.5
+TRUSTED_PROXY_IPS=127.0.0.1,::1
+
+# Upstash Redis REST credentials for durable rate limiting
+# Set both values to enable persistent rate limiting across deployments
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
 import { ratelimit } from '@/lib/ratelimit';
+import { isIP } from 'net';
 
 const contactSchema = z.object({
   name: z.string().min(2, "Name must be at least 2 characters"),
@@ -23,10 +24,66 @@ interface ApiResponse {
   };
 }
 
+function normalizeIp(ip: string | undefined | null): string | null {
+  if (!ip) {
+    return null;
+  }
+
+  // Handle IPv6 mapped IPv4 addresses (e.g. ::ffff:127.0.0.1)
+  const mappedMatch = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mappedMatch) {
+    return mappedMatch[1];
+  }
+
+  return ip;
+}
+
+function getTrustedProxies(): Set<string> {
+  const raw = process.env.TRUSTED_PROXY_IPS;
+  const defaults = ['127.0.0.1', '::1'];
+
+  if (!raw) {
+    return new Set(defaults);
+  }
+
+  return new Set(
+    raw
+      .split(',')
+      .map(value => normalizeIp(value.trim()))
+      .filter((value): value is string => Boolean(value)),
+  );
+}
+
 function getClientIp(req: NextApiRequest): string {
-  const forwarded = req.headers['x-forwarded-for'];
-  const ip = typeof forwarded === 'string' ? forwarded.split(',')[0] : req.socket.remoteAddress;
-  return ip || 'unknown';
+  const trustedProxies = getTrustedProxies();
+  const remoteAddress = normalizeIp(req.socket.remoteAddress);
+
+  if (remoteAddress && trustedProxies.has(remoteAddress)) {
+    const forwarded = req.headers['x-forwarded-for'];
+    const candidates: string[] = [];
+
+    if (typeof forwarded === 'string') {
+      candidates.push(...forwarded.split(',').map(ip => ip.trim()));
+    } else if (Array.isArray(forwarded)) {
+      candidates.push(...forwarded.flatMap(value => value.split(',')).map(ip => ip.trim()));
+    }
+
+    const realIp = candidates.find(ip => isIP(ip));
+    if (realIp) {
+      return normalizeIp(realIp) ?? 'unknown';
+    }
+
+    const realIpHeader = normalizeIp(Array.isArray(req.headers['x-real-ip']) ? req.headers['x-real-ip'][0] : req.headers['x-real-ip']);
+    if (realIpHeader) {
+      return realIpHeader;
+    }
+  }
+
+  if (remoteAddress) {
+    return remoteAddress;
+  }
+
+  return 'unknown';
 }
 
 export default async function handler(
@@ -45,10 +102,14 @@ export default async function handler(
   if (origin && allowedOrigins.includes(origin)) {
     res.setHeader('Access-Control-Allow-Origin', origin);
   }
-  
+
   res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
   res.setHeader('Access-Control-Max-Age', '86400');
+
+  const existingVary = res.getHeader('Vary');
+  const varyHeader = Array.isArray(existingVary) ? existingVary.join(', ') : existingVary;
+  res.setHeader('Vary', varyHeader ? `${varyHeader}, Origin` : 'Origin');
 
   if (req.method === 'OPTIONS') {
     res.status(200).end();
@@ -56,12 +117,13 @@ export default async function handler(
   }
 
   if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST, OPTIONS');
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
   // Rate Limiting
   const clientIp = getClientIp(req);
-  const rateLimitResult = ratelimit.check(clientIp);
+  const rateLimitResult = await ratelimit.check(clientIp);
   
   // Set rate limit headers
   res.setHeader('X-RateLimit-Limit', rateLimitResult.limit.toString());
@@ -81,16 +143,11 @@ export default async function handler(
   try {
     const data: ContactFormData = contactSchema.parse(req.body);
     
-    // Log the submission
-    console.log('📧 New TACTEC contact form submission:', {
+    // Log anonymised submission metadata for operational insight without PII exposure
+    console.info('📧 New TACTEC contact form submission received', {
       timestamp: new Date().toISOString(),
-      name: data.name,
-      email: data.email,
-      club: data.club,
-      role: data.role,
       requestType: data.requestType,
-      messagePreview: data.message.substring(0, 100) + (data.message.length > 100 ? '...' : ''),
-      ip: clientIp,
+      messageLength: data.message.length,
     });
 
     // In production, you would:


### PR DESCRIPTION
## Summary
- enforce trusted-proxy-aware client IP extraction, improved CORS caching headers, and explicit Allow responses in the contact API
- add a durable Upstash-backed rate limiter with automatic in-memory fallback and document the required environment variables
- remove logging of contact form personally identifiable information while keeping operational insights

## Testing
- not run (local Next.js lint command requires interactive setup)


------
https://chatgpt.com/codex/tasks/task_e_68dc390eb024832a929081c5c876a61e