### PR TITLE
Swap header wordmark for accessible logo component

### DIFF
--- a/src/components/TacTecLanding.tsx
+++ b/src/components/TacTecLanding.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import LanguageSwitcher from "./LanguageSwitcher";
 import StructuredData from "./StructuredData";
+import TacTecLogo from "./TacTecLogo";
 import { SITE_URL } from "@/config/env";
 import { trackEvent } from "@/utils/analytics";
 
@@ -103,9 +104,11 @@ export default function TacTecLanding() {
           <div className="flex items-center justify-between">
             <Link
               href="/"
-              className="text-2xl font-bold text-sky-600 hover:text-sky-700 transition"
+              className="flex items-center text-sky-600 transition hover:text-sky-700 dark:text-sky-400 dark:hover:text-sky-300"
+              aria-label="TACTEC homepage"
             >
-              TACTEC
+              <span className="sr-only">TACTEC</span>
+              <TacTecLogo className="h-10 w-auto" />
             </Link>
             <div className="flex items-center gap-4">
               <div className="hidden md:flex gap-6">

--- a/src/components/TacTecLogo.tsx
+++ b/src/components/TacTecLogo.tsx
@@ -1,0 +1,49 @@
+import { memo, useId } from "react";
+import clsx from "clsx";
+
+type TacTecLogoProps = {
+  className?: string;
+  title?: string;
+};
+
+function TacTecLogoComponent({ className, title = "TACTEC" }: TacTecLogoProps) {
+  const titleId = useId();
+
+  return (
+    <svg
+      viewBox="0 0 360 120"
+      role="img"
+      aria-labelledby={titleId}
+      className={clsx("h-full w-full", className)}
+    >
+      <title id={titleId}>{title}</title>
+      <rect width="360" height="120" rx="16" fill="currentColor" />
+      <g fill="#fff" fontFamily="'Montserrat', 'Helvetica Neue', Arial, sans-serif" fontWeight={700}>
+        <text
+          x="180"
+          y="74"
+          textAnchor="middle"
+          fontSize="64"
+          letterSpacing="18"
+        >
+          TACT
+        </text>
+        <text
+          x="180"
+          y="110"
+          textAnchor="middle"
+          fontSize="48"
+          letterSpacing="40"
+        >
+          EC
+        </text>
+      </g>
+    </svg>
+  );
+}
+
+const TacTecLogo = memo(TacTecLogoComponent);
+
+TacTecLogo.displayName = "TacTecLogo";
+
+export default TacTecLogo;


### PR DESCRIPTION
## Summary
- replace the navigation brand text with a reusable TacTecLogo SVG component and maintain accessible labeling
- style the logo link for light and dark themes while keeping the sr-only text for screen readers

## Testing
- npm run lint *(fails: prompts for Next.js ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68dc57febbf4832abfac8018072bafee