### PR TITLE
Replace header logo with official asset

### DIFF
--- a/src/components/TacTecLanding.tsx
+++ b/src/components/TacTecLanding.tsx
@@ -103,17 +103,17 @@ export default function TacTecLanding() {
           <div className="flex items-center justify-between">
             <Link
               href="/"
-              className="flex items-center transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+              className="flex items-center text-sky-600 transition hover:text-sky-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 dark:text-sky-400 dark:hover:text-sky-300"
               aria-label="TACTEC homepage"
             >
               <span className="sr-only">TACTEC</span>
               <Image
-                src="/icons/icon1.png"
+                src="/icons/icon0.svg"
                 alt="TACTEC logo"
-                width={96}
-                height={96}
+                width={294}
+                height={281}
                 priority
-                className="h-10 w-10"
+                className="h-10 w-auto"
               />
             </Link>
             <div className="flex items-center gap-4">

--- a/src/components/TacTecLanding.tsx
+++ b/src/components/TacTecLanding.tsx
@@ -108,12 +108,12 @@ export default function TacTecLanding() {
             >
               <span className="sr-only">TACTEC</span>
               <Image
-                src="/icons/icon0.svg"
+                src="/icons/icon1.png"
                 alt="TACTEC logo"
-                width={120}
-                height={120}
+                width={96}
+                height={96}
                 priority
-                className="h-10 w-auto"
+                className="h-10 w-10"
               />
             </Link>
             <div className="flex items-center gap-4">

--- a/src/components/TacTecLanding.tsx
+++ b/src/components/TacTecLanding.tsx
@@ -103,7 +103,7 @@ export default function TacTecLanding() {
           <div className="flex items-center justify-between">
             <Link
               href="/"
-              className="flex items-center transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+              className="flex items-center text-sky-600 transition hover:text-sky-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 dark:text-sky-400 dark:hover:text-sky-300"
               aria-label="TACTEC homepage"
             >
               <span className="sr-only">TACTEC</span>
@@ -113,7 +113,7 @@ export default function TacTecLanding() {
                 width={96}
                 height={96}
                 priority
-                className="h-10 w-10"
+                className="h-10 w-auto"
               />
             </Link>
             <div className="flex items-center gap-4">

--- a/src/components/TacTecLanding.tsx
+++ b/src/components/TacTecLanding.tsx
@@ -103,15 +103,15 @@ export default function TacTecLanding() {
           <div className="flex items-center justify-between">
             <Link
               href="/"
-              className="flex items-center text-sky-600 transition hover:text-sky-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 dark:text-sky-400 dark:hover:text-sky-300"
+              className="flex items-center transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
               aria-label="TACTEC homepage"
             >
               <span className="sr-only">TACTEC</span>
               <Image
-                src="/icons/icon1.png"
+                src="/icons/icon0.svg"
                 alt="TACTEC logo"
-                width={96}
-                height={96}
+                width={120}
+                height={120}
                 priority
                 className="h-10 w-auto"
               />

--- a/src/components/TacTecLanding.tsx
+++ b/src/components/TacTecLanding.tsx
@@ -103,9 +103,18 @@ export default function TacTecLanding() {
           <div className="flex items-center justify-between">
             <Link
               href="/"
-              className="text-2xl font-bold text-sky-600 hover:text-sky-700 transition"
+              className="flex items-center transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+              aria-label="TACTEC homepage"
             >
-              TACTEC
+              <span className="sr-only">TACTEC</span>
+              <Image
+                src="/icons/icon1.png"
+                alt="TACTEC logo"
+                width={96}
+                height={96}
+                priority
+                className="h-10 w-10"
+              />
             </Link>
             <div className="flex items-center gap-4">
               <div className="hidden md:flex gap-6">


### PR DESCRIPTION
## Summary
- display the official TACTEC icon in the header navigation link instead of the generated SVG
- remove the unused TacTecLogo component now that the image asset is used directly

## Testing
- npm run lint *(fails: prompts for Next.js ESLint configuration setup)*

------
https://chatgpt.com/codex/tasks/task_e_68dc57febbf4832abfac8018072bafee