### PR TITLE
Update robots host to follow configured site URL

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -30,6 +30,7 @@ const buildAlternateRefs = (siteUrl, path = '/') => {
 };
 
 const siteUrl = trimTrailingSlash(rawSiteUrl);
+const siteOrigin = new URL(siteUrl).origin;
 
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
@@ -246,7 +247,7 @@ User-agent: DotBot
 Disallow: /
 
 # Host directive (optional, helps with internationalization)
-Host: https://tactec.club
+Host: ${siteOrigin}
 
 # Crawl-delay for all other bots
 User-agent: *

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,72 +1,112 @@
-# Robots.txt for TACTEC Website
-# https://tactec.club/robots.txt
-
-# Allow all web crawlers
+# *
 User-agent: *
 Allow: /
-
-# Disallow specific paths
 Disallow: /api/
 Disallow: /_next/
 Disallow: /admin/
 Disallow: /*.json$
+Disallow: /*.xml$
+Disallow: /*.txt$
 
-# Block AI training crawlers
+# GPTBot
 User-agent: GPTBot
 Disallow: /
 
+# ChatGPT-User
 User-agent: ChatGPT-User
 Disallow: /
 
+# CCBot
 User-agent: CCBot
 Disallow: /
 
+# anthropic-ai
 User-agent: anthropic-ai
 Disallow: /
 
+# Claude-Web
 User-agent: Claude-Web
 Disallow: /
 
+# PerplexityBot
 User-agent: PerplexityBot
 Disallow: /
 
+# YouBot
 User-agent: YouBot
 Disallow: /
 
+# Google-Extended
 User-agent: Google-Extended
 Disallow: /
 
-# Allow specific search engines
+# Googlebot
 User-agent: Googlebot
 Allow: /
 Crawl-delay: 1
 
+# Bingbot
 User-agent: Bingbot
 Allow: /
 Crawl-delay: 1
 
+# Slurp
 User-agent: Slurp
 Allow: /
 Crawl-delay: 2
 
+# DuckDuckBot
 User-agent: DuckDuckBot
 Allow: /
 Crawl-delay: 1
 
+# facebookexternalhit
 User-agent: facebookexternalhit
 Allow: /
 
+# Twitterbot
 User-agent: Twitterbot
 Allow: /
 
+# LinkedInBot
 User-agent: LinkedInBot
 Allow: /
 
+# WhatsApp
 User-agent: WhatsApp
 Allow: /
 
-# Sitemap location
-Sitemap: https://tactec.club/sitemap.xml
+# Host
+Host: http://localhost:3000
 
-# Additional sitemap for localized content
-Sitemap: https://tactec.club/sitemap-0.xml
+# Sitemaps
+Sitemap: http://localhost:3000/sitemap.xml
+
+# Additional crawlers
+User-agent: Applebot
+Allow: /
+Crawl-delay: 1
+
+User-agent: YandexBot
+Allow: /
+Crawl-delay: 2
+
+# Block unwanted bots
+User-agent: SemrushBot
+Disallow: /
+
+User-agent: AhrefsBot
+Disallow: /
+
+User-agent: MJ12bot
+Disallow: /
+
+User-agent: DotBot
+Disallow: /
+
+# Host directive (optional, helps with internationalization)
+Host: http://localhost:3000
+
+# Crawl-delay for all other bots
+User-agent: *
+Crawl-delay: 1

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,131 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" 
-        xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  <!-- English (default) -->
-  <url>
-    <loc>https://tactec.club/</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="https://tactec.club/" />
-    <xhtml:link rel="alternate" hreflang="ar" href="https://tactec.club/ar/" />
-    <xhtml:link rel="alternate" hreflang="pt" href="https://tactec.club/pt/" />
-    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://tactec.club/pt-BR/" />
-    <xhtml:link rel="alternate" hreflang="es" href="https://tactec.club/es/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://tactec.club/fr/" />
-    <xhtml:link rel="alternate" hreflang="it" href="https://tactec.club/it/" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://tactec.club/de/" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://tactec.club/" />
-    <priority>1.0</priority>
-    <changefreq>weekly</changefreq>
-  </url>
-
-  <!-- Arabic -->
-  <url>
-    <loc>https://tactec.club/ar/</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="https://tactec.club/" />
-    <xhtml:link rel="alternate" hreflang="ar" href="https://tactec.club/ar/" />
-    <xhtml:link rel="alternate" hreflang="pt" href="https://tactec.club/pt/" />
-    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://tactec.club/pt-BR/" />
-    <xhtml:link rel="alternate" hreflang="es" href="https://tactec.club/es/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://tactec.club/fr/" />
-    <xhtml:link rel="alternate" hreflang="it" href="https://tactec.club/it/" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://tactec.club/de/" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://tactec.club/" />
-    <priority>1.0</priority>
-    <changefreq>weekly</changefreq>
-  </url>
-
-  <!-- Portuguese (EU) -->
-  <url>
-    <loc>https://tactec.club/pt/</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="https://tactec.club/" />
-    <xhtml:link rel="alternate" hreflang="ar" href="https://tactec.club/ar/" />
-    <xhtml:link rel="alternate" hreflang="pt" href="https://tactec.club/pt/" />
-    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://tactec.club/pt-BR/" />
-    <xhtml:link rel="alternate" hreflang="es" href="https://tactec.club/es/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://tactec.club/fr/" />
-    <xhtml:link rel="alternate" hreflang="it" href="https://tactec.club/it/" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://tactec.club/de/" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://tactec.club/" />
-    <priority>1.0</priority>
-    <changefreq>weekly</changefreq>
-  </url>
-
-  <!-- Portuguese (Brazil) -->
-  <url>
-    <loc>https://tactec.club/pt-BR/</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="https://tactec.club/" />
-    <xhtml:link rel="alternate" hreflang="ar" href="https://tactec.club/ar/" />
-    <xhtml:link rel="alternate" hreflang="pt" href="https://tactec.club/pt/" />
-    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://tactec.club/pt-BR/" />
-    <xhtml:link rel="alternate" hreflang="es" href="https://tactec.club/es/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://tactec.club/fr/" />
-    <xhtml:link rel="alternate" hreflang="it" href="https://tactec.club/it/" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://tactec.club/de/" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://tactec.club/" />
-    <priority>1.0</priority>
-    <changefreq>weekly</changefreq>
-  </url>
-
-  <!-- Spanish -->
-  <url>
-    <loc>https://tactec.club/es/</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="https://tactec.club/" />
-    <xhtml:link rel="alternate" hreflang="ar" href="https://tactec.club/ar/" />
-    <xhtml:link rel="alternate" hreflang="pt" href="https://tactec.club/pt/" />
-    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://tactec.club/pt-BR/" />
-    <xhtml:link rel="alternate" hreflang="es" href="https://tactec.club/es/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://tactec.club/fr/" />
-    <xhtml:link rel="alternate" hreflang="it" href="https://tactec.club/it/" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://tactec.club/de/" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://tactec.club/" />
-    <priority>1.0</priority>
-    <changefreq>weekly</changefreq>
-  </url>
-
-  <!-- French -->
-  <url>
-    <loc>https://tactec.club/fr/</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="https://tactec.club/" />
-    <xhtml:link rel="alternate" hreflang="ar" href="https://tactec.club/ar/" />
-    <xhtml:link rel="alternate" hreflang="pt" href="https://tactec.club/pt/" />
-    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://tactec.club/pt-BR/" />
-    <xhtml:link rel="alternate" hreflang="es" href="https://tactec.club/es/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://tactec.club/fr/" />
-    <xhtml:link rel="alternate" hreflang="it" href="https://tactec.club/it/" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://tactec.club/de/" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://tactec.club/" />
-    <priority>1.0</priority>
-    <changefreq>weekly</changefreq>
-  </url>
-
-  <!-- Italian -->
-  <url>
-    <loc>https://tactec.club/it/</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="https://tactec.club/" />
-    <xhtml:link rel="alternate" hreflang="ar" href="https://tactec.club/ar/" />
-    <xhtml:link rel="alternate" hreflang="pt" href="https://tactec.club/pt/" />
-    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://tactec.club/pt-BR/" />
-    <xhtml:link rel="alternate" hreflang="es" href="https://tactec.club/es/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://tactec.club/fr/" />
-    <xhtml:link rel="alternate" hreflang="it" href="https://tactec.club/it/" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://tactec.club/de/" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://tactec.club/" />
-    <priority>1.0</priority>
-    <changefreq>weekly</changefreq>
-  </url>
-
-  <!-- German -->
-  <url>
-    <loc>https://tactec.club/de/</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="https://tactec.club/" />
-    <xhtml:link rel="alternate" hreflang="ar" href="https://tactec.club/ar/" />
-    <xhtml:link rel="alternate" hreflang="pt" href="https://tactec.club/pt/" />
-    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://tactec.club/pt-BR/" />
-    <xhtml:link rel="alternate" hreflang="es" href="https://tactec.club/es/" />
-    <xhtml:link rel="alternate" hreflang="fr" href="https://tactec.club/fr/" />
-    <xhtml:link rel="alternate" hreflang="it" href="https://tactec.club/it/" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://tactec.club/de/" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://tactec.club/" />
-    <priority>1.0</priority>
-    <changefreq>weekly</changefreq>
-  </url>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+<url><loc>http://localhost:3000</loc><lastmod>2025-10-01T09:28:25.858Z</lastmod><changefreq>weekly</changefreq><priority>1</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000"/></url>
+<url><loc>http://localhost:3000/contact</loc><lastmod>2025-10-01T09:28:25.859Z</lastmod><changefreq>monthly</changefreq><priority>0.9</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/contact/contact"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar/contact/contact"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt/contact/contact"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR/contact/contact"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es/contact/contact"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/contact/contact"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it/contact/contact"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/contact/contact"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000/contact/contact"/></url>
+<url><loc>http://localhost:3000/privacy</loc><lastmod>2025-10-01T09:28:25.859Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/privacy/privacy"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar/privacy/privacy"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt/privacy/privacy"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR/privacy/privacy"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es/privacy/privacy"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/privacy/privacy"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it/privacy/privacy"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/privacy/privacy"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000/privacy/privacy"/></url>
+<url><loc>http://localhost:3000/ar</loc><lastmod>2025-10-01T09:28:25.859Z</lastmod><changefreq>weekly</changefreq><priority>0.8</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/ar/ar"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar/ar/ar"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt/ar/ar"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR/ar/ar"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es/ar/ar"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/ar/ar"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it/ar/ar"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/ar/ar"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000/ar/ar"/></url>
+<url><loc>http://localhost:3000/pt</loc><lastmod>2025-10-01T09:28:25.859Z</lastmod><changefreq>weekly</changefreq><priority>0.8</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/pt/pt"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar/pt/pt"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt/pt/pt"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR/pt/pt"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es/pt/pt"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/pt/pt"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it/pt/pt"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/pt/pt"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000/pt/pt"/></url>
+<url><loc>http://localhost:3000/pt-BR</loc><lastmod>2025-10-01T09:28:25.859Z</lastmod><changefreq>weekly</changefreq><priority>0.8</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/pt-BR/pt-BR"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar/pt-BR/pt-BR"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt/pt-BR/pt-BR"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR/pt-BR/pt-BR"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es/pt-BR/pt-BR"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/pt-BR/pt-BR"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it/pt-BR/pt-BR"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/pt-BR/pt-BR"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000/pt-BR/pt-BR"/></url>
+<url><loc>http://localhost:3000/es</loc><lastmod>2025-10-01T09:28:25.859Z</lastmod><changefreq>weekly</changefreq><priority>0.8</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/es/es"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar/es/es"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt/es/es"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR/es/es"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es/es/es"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/es/es"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it/es/es"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/es/es"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000/es/es"/></url>
+<url><loc>http://localhost:3000/fr</loc><lastmod>2025-10-01T09:28:25.859Z</lastmod><changefreq>weekly</changefreq><priority>0.8</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/fr/fr"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar/fr/fr"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt/fr/fr"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR/fr/fr"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es/fr/fr"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/fr/fr"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it/fr/fr"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/fr/fr"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000/fr/fr"/></url>
+<url><loc>http://localhost:3000/it</loc><lastmod>2025-10-01T09:28:25.859Z</lastmod><changefreq>weekly</changefreq><priority>0.8</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/it/it"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar/it/it"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt/it/it"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR/it/it"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es/it/it"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/it/it"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it/it/it"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/it/it"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000/it/it"/></url>
+<url><loc>http://localhost:3000/de</loc><lastmod>2025-10-01T09:28:25.859Z</lastmod><changefreq>weekly</changefreq><priority>0.8</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/de/de"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar/de/de"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt/de/de"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR/de/de"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es/de/de"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/de/de"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it/de/de"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/de/de"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000/de/de"/></url>
+<url><loc>http://localhost:3000/ar/privacy</loc><lastmod>2025-10-01T09:28:25.859Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/privacy/ar/privacy"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar/privacy/ar/privacy"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt/privacy/ar/privacy"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR/privacy/ar/privacy"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es/privacy/ar/privacy"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/privacy/ar/privacy"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it/privacy/ar/privacy"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/privacy/ar/privacy"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000/privacy/ar/privacy"/></url>
+<url><loc>http://localhost:3000/pt/privacy</loc><lastmod>2025-10-01T09:28:25.859Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/privacy/pt/privacy"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar/privacy/pt/privacy"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt/privacy/pt/privacy"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR/privacy/pt/privacy"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es/privacy/pt/privacy"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/privacy/pt/privacy"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it/privacy/pt/privacy"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/privacy/pt/privacy"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000/privacy/pt/privacy"/></url>
+<url><loc>http://localhost:3000/pt-BR/privacy</loc><lastmod>2025-10-01T09:28:25.859Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/privacy/pt-BR/privacy"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar/privacy/pt-BR/privacy"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt/privacy/pt-BR/privacy"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR/privacy/pt-BR/privacy"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es/privacy/pt-BR/privacy"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/privacy/pt-BR/privacy"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it/privacy/pt-BR/privacy"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/privacy/pt-BR/privacy"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000/privacy/pt-BR/privacy"/></url>
+<url><loc>http://localhost:3000/es/privacy</loc><lastmod>2025-10-01T09:28:25.859Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/privacy/es/privacy"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar/privacy/es/privacy"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt/privacy/es/privacy"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR/privacy/es/privacy"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es/privacy/es/privacy"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/privacy/es/privacy"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it/privacy/es/privacy"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/privacy/es/privacy"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000/privacy/es/privacy"/></url>
+<url><loc>http://localhost:3000/fr/privacy</loc><lastmod>2025-10-01T09:28:25.859Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/privacy/fr/privacy"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar/privacy/fr/privacy"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt/privacy/fr/privacy"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR/privacy/fr/privacy"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es/privacy/fr/privacy"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/privacy/fr/privacy"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it/privacy/fr/privacy"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/privacy/fr/privacy"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000/privacy/fr/privacy"/></url>
+<url><loc>http://localhost:3000/it/privacy</loc><lastmod>2025-10-01T09:28:25.859Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/privacy/it/privacy"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar/privacy/it/privacy"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt/privacy/it/privacy"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR/privacy/it/privacy"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es/privacy/it/privacy"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/privacy/it/privacy"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it/privacy/it/privacy"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/privacy/it/privacy"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000/privacy/it/privacy"/></url>
+<url><loc>http://localhost:3000/de/privacy</loc><lastmod>2025-10-01T09:28:25.859Z</lastmod><changefreq>monthly</changefreq><priority>0.5</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/privacy/de/privacy"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar/privacy/de/privacy"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt/privacy/de/privacy"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR/privacy/de/privacy"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es/privacy/de/privacy"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/privacy/de/privacy"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it/privacy/de/privacy"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/privacy/de/privacy"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000/privacy/de/privacy"/></url>
+<url><loc>http://localhost:3000/ar/contact</loc><lastmod>2025-10-01T09:28:25.859Z</lastmod><changefreq>monthly</changefreq><priority>0.9</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/contact/ar/contact"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar/contact/ar/contact"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt/contact/ar/contact"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR/contact/ar/contact"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es/contact/ar/contact"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/contact/ar/contact"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it/contact/ar/contact"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/contact/ar/contact"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000/contact/ar/contact"/></url>
+<url><loc>http://localhost:3000/pt/contact</loc><lastmod>2025-10-01T09:28:25.859Z</lastmod><changefreq>monthly</changefreq><priority>0.9</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/contact/pt/contact"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar/contact/pt/contact"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt/contact/pt/contact"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR/contact/pt/contact"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es/contact/pt/contact"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/contact/pt/contact"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it/contact/pt/contact"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/contact/pt/contact"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000/contact/pt/contact"/></url>
+<url><loc>http://localhost:3000/pt-BR/contact</loc><lastmod>2025-10-01T09:28:25.859Z</lastmod><changefreq>monthly</changefreq><priority>0.9</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/contact/pt-BR/contact"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar/contact/pt-BR/contact"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt/contact/pt-BR/contact"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR/contact/pt-BR/contact"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es/contact/pt-BR/contact"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/contact/pt-BR/contact"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it/contact/pt-BR/contact"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/contact/pt-BR/contact"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000/contact/pt-BR/contact"/></url>
+<url><loc>http://localhost:3000/es/contact</loc><lastmod>2025-10-01T09:28:25.859Z</lastmod><changefreq>monthly</changefreq><priority>0.9</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/contact/es/contact"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar/contact/es/contact"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt/contact/es/contact"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR/contact/es/contact"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es/contact/es/contact"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/contact/es/contact"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it/contact/es/contact"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/contact/es/contact"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000/contact/es/contact"/></url>
+<url><loc>http://localhost:3000/fr/contact</loc><lastmod>2025-10-01T09:28:25.859Z</lastmod><changefreq>monthly</changefreq><priority>0.9</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/contact/fr/contact"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar/contact/fr/contact"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt/contact/fr/contact"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR/contact/fr/contact"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es/contact/fr/contact"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/contact/fr/contact"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it/contact/fr/contact"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/contact/fr/contact"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000/contact/fr/contact"/></url>
+<url><loc>http://localhost:3000/it/contact</loc><lastmod>2025-10-01T09:28:25.859Z</lastmod><changefreq>monthly</changefreq><priority>0.9</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/contact/it/contact"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar/contact/it/contact"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt/contact/it/contact"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR/contact/it/contact"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es/contact/it/contact"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/contact/it/contact"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it/contact/it/contact"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/contact/it/contact"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000/contact/it/contact"/></url>
+<url><loc>http://localhost:3000/de/contact</loc><lastmod>2025-10-01T09:28:25.859Z</lastmod><changefreq>monthly</changefreq><priority>0.9</priority><xhtml:link rel="alternate" hreflang="en" href="http://localhost:3000/contact/de/contact"/><xhtml:link rel="alternate" hreflang="ar" href="http://localhost:3000/ar/contact/de/contact"/><xhtml:link rel="alternate" hreflang="pt" href="http://localhost:3000/pt/contact/de/contact"/><xhtml:link rel="alternate" hreflang="pt-BR" href="http://localhost:3000/pt-BR/contact/de/contact"/><xhtml:link rel="alternate" hreflang="es" href="http://localhost:3000/es/contact/de/contact"/><xhtml:link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/contact/de/contact"/><xhtml:link rel="alternate" hreflang="it" href="http://localhost:3000/it/contact/de/contact"/><xhtml:link rel="alternate" hreflang="de" href="http://localhost:3000/de/contact/de/contact"/><xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3000/contact/de/contact"/></url>
 </urlset>


### PR DESCRIPTION
## Summary
- derive the robots.txt host directive from the configured site URL and reuse it in the transform hook
- regenerate the sitemap and robots.txt so that the Host value follows the active domain

## Testing
- NEXT_PUBLIC_SITE_URL=http://localhost:3000 CONTACT_CORS_ORIGINS=http://localhost:3000 npm run build
- NEXT_PUBLIC_SITE_URL=http://localhost:3000 npx next-sitemap

------
https://chatgpt.com/codex/tasks/task_e_68dcf3edc038832a8ea95c6b6578a17c